### PR TITLE
Import entries in two phases instead of one

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "launchy"
 gem "inifile"
 gem "contentful-management"
-gem "contentful", "~> 0.7"
+gem "contentful", "~> 0.7", ">= 0.7.3"

--- a/lib/contentful/bootstrap/templates/blog.rb
+++ b/lib/contentful/bootstrap/templates/blog.rb
@@ -59,11 +59,13 @@ module Contentful
             ],
             'post' => [
               {
+                'id' => 'inferno',
                 'title' => 'Inferno',
                 'content' => 'Inferno is the last book in Dan Brown\'s collection...',
                 'author' => Links::Entry.new('dan_brown')
               },
               {
+                'id' => 'alturas',
                 'title' => 'Alturas de Macchu Picchu',
                 'content' => 'Alturas de Macchu Picchu is one of Pablo Neruda\'s most famous poetry books...',
                 'author' => Links::Entry.new('pablo_neruda')

--- a/spec/fixtures/vcr_fixtures/create_space_with_blog_template.yml
+++ b/spec/fixtures/vcr_fixtures/create_space_with_blog_template.yml
@@ -8,11 +8,13 @@ http_interactions:
       string: '{"name":"blog_space","defaultLocale":"en-US"}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
+      X-Contentful-Organization:
+      - 1PLOOEmTI2S1NYald2TemO
       Connection:
       - close
       Host:
@@ -29,7 +31,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -39,11 +41,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:36 GMT
+      - Fri, 27 Nov 2015 09:17:18 GMT
       Etag:
-      - '"56404e690e6b747ae9040984175e4dcf"'
+      - '"72393227d0b0f99d0adcbe1230a4abea"'
       Location:
-      - https://api.contentful.com/spaces/zred3m25k5em
+      - https://api.contentful.com/spaces/xrfaz3bfkml6
       Server:
       - nginx
       Status:
@@ -53,7 +55,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - b89-1468506509
+      - 9e1-621575638
       Content-Length:
       - '453'
       Connection:
@@ -64,40 +66,40 @@ http_interactions:
         {
           "sys":{
             "type":"Space",
-            "id":"zred3m25k5em",
+            "id":"xrfaz3bfkml6",
             "version":1,
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-18T15:24:35Z",
+            "createdAt":"2015-11-27T09:17:16Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-18T15:24:35Z"
+            "updatedAt":"2015-11-27T09:17:16Z"
           },
           "name":"blog_space"
         }
 
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:36 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:20 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/content_types/author
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/content_types/author
     body:
       encoding: UTF-8
       string: '{"displayField":"name","name":"Author","description":null,"fields":[{"id":"name","name":"Author
         Name","type":"Symbol"}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -116,19 +118,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:38 GMT
+      - Fri, 27 Nov 2015 09:17:22 GMT
       Etag:
-      - '"1149fa4851540eeca71043bda9e66c61"'
+      - '"b978cb9f09a17641076cc5feb03af951"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -136,7 +138,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6I4fPmc3DiKGscSwy0m0Ka
+      - content-api:6ggis53r7Uk4eU2CckIaC4
       X-Powered-By:
       - Express
       Content-Length:
@@ -163,42 +165,42 @@ http_interactions:
             "id": "author",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T15:24:38.141Z",
+            "createdAt": "2015-11-27T09:17:22.748Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
-            "updatedAt": "2015-11-18T15:24:38.141Z",
+            "updatedAt": "2015-11-27T09:17:22.748Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:38 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:24 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/content_types/author/published
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/content_types/author/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -221,19 +223,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:39 GMT
+      - Fri, 27 Nov 2015 09:17:27 GMT
       Etag:
-      - '"a72b809b3b60c5d17dfeb057844201ac"'
+      - '"85590642c6c40e8773542f546634208c"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -241,7 +243,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1C63n263NuIAM28AgUIEg0
+      - content-api:1TeFCdSYFSGyIKeOcIYKG2
       X-Powered-By:
       - Express
       Content-Length:
@@ -267,55 +269,55 @@ http_interactions:
           "sys": {
             "id": "author",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:24:38.141Z",
+            "createdAt": "2015-11-27T09:17:22.748Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:24:38.894Z",
+            "updatedAt": "2015-11-27T09:17:26.724Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:24:38.894Z",
+            "firstPublishedAt": "2015-11-27T09:17:26.724Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:24:38.894Z",
+            "publishedAt": "2015-11-27T09:17:26.724Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:39 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:28 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/content_types/post
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/content_types/post
     body:
       encoding: UTF-8
       string: '{"displayField":"title","name":"Post","description":null,"fields":[{"id":"title","name":"Post
         Title","type":"Symbol"},{"id":"content","name":"Content","type":"Text"},{"id":"author","name":"Author","type":"Link","linkType":"Entry"}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -334,19 +336,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:40 GMT
+      - Fri, 27 Nov 2015 09:17:28 GMT
       Etag:
-      - '"d023239081458fcb1c2a27f352fc233d"'
+      - '"59bd44b600fabcf92cb69245b804869b"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -354,7 +356,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:sfIXixYN0co22GKae0asq
+      - content-api:2BsKsWT3UkMm28UeW2O8CG
       X-Powered-By:
       - Express
       Content-Length:
@@ -396,42 +398,42 @@ http_interactions:
             "id": "post",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T15:24:40.401Z",
+            "createdAt": "2015-11-27T09:17:28.093Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
-            "updatedAt": "2015-11-18T15:24:40.401Z",
+            "updatedAt": "2015-11-27T09:17:28.093Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:40 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:29 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/content_types/post/published
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/content_types/post/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -454,19 +456,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:41 GMT
+      - Fri, 27 Nov 2015 09:17:32 GMT
       Etag:
-      - '"00ff9f12fc92ed631f2aa8da61c29002"'
+      - '"3778cb214dda7bd58741eb6656dd3f18"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -474,7 +476,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4ZWI7sfBEcGAMcwwwgQKE8
+      - content-api:5TyMY7de1iwKeOUawwoG6q
       X-Powered-By:
       - Express
       Content-Length:
@@ -515,54 +517,54 @@ http_interactions:
           "sys": {
             "id": "post",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:24:40.401Z",
+            "createdAt": "2015-11-27T09:17:28.093Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:24:41.217Z",
+            "updatedAt": "2015-11-27T09:17:31.703Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:24:41.217Z",
+            "firstPublishedAt": "2015-11-27T09:17:31.703Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:24:41.217Z",
+            "publishedAt": "2015-11-27T09:17:31.703Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:41 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:33 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/zred3m25k5em/content_types/author
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/content_types/author
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -583,19 +585,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:42 GMT
+      - Fri, 27 Nov 2015 09:17:32 GMT
       Etag:
-      - '"02d0a0f51497beeea4b81d7d896cfa8a"'
+      - '"6cbdef6a200045f02876aec0e45505b3"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -603,7 +605,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5bImc8qsNag4MWeycOOW6
+      - content-api:3HJL254NIAWCSQmyw4QY4G
       X-Powered-By:
       - Express
       Content-Length:
@@ -629,54 +631,54 @@ http_interactions:
           "sys": {
             "id": "author",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:24:38.141Z",
+            "createdAt": "2015-11-27T09:17:22.748Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:24:38.894Z",
+            "firstPublishedAt": "2015-11-27T09:17:26.724Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:24:38.894Z",
+            "publishedAt": "2015-11-27T09:17:26.724Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T15:24:38.958Z",
+            "updatedAt": "2015-11-27T09:17:26.771Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:42 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:34 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/dan_brown
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/dan_brown
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Dan Brown"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -697,19 +699,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:43 GMT
+      - Fri, 27 Nov 2015 09:17:33 GMT
       Etag:
-      - '"76375421ad396ec8c4649c66e23dd0ec"'
+      - '"13065344e1279ea6362b517598b00cd1"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -717,39 +719,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6nyLmHNX5CCK2M0G2E0AEa
+      - content-api:7G2QcoRx96gUACqWgaYUEO
       X-Powered-By:
       - Express
       Content-Length:
-      - '776'
+      - '726'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Dan Brown"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "dan_brown",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:24:43.613Z",
+            "createdAt": "2015-11-27T09:17:33.725Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -759,27 +757,27 @@ http_interactions:
                 "id": "author"
               }
             },
-            "updatedAt": "2015-11-18T15:24:43.613Z",
+            "updatedAt": "2015-11-27T09:17:33.725Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:43 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:35 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/dan_brown
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/dan_brown
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Dan Brown"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -800,19 +798,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:44 GMT
+      - Fri, 27 Nov 2015 09:17:34 GMT
       Etag:
-      - '"6dcbccfc30b84a589325a9fd052f153d"'
+      - '"91e0ffac2f126028745413d5c9b629da"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -820,38 +818,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:fyASbr1JYWgCie4uw8s8W
+      - content-api:H34alNwH4GSweWUuUmw0S
       X-Powered-By:
       - Express
       Content-Length:
-      - '776'
+      - '726'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Dan Brown"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "dan_brown",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:24:43.613Z",
+            "createdAt": "2015-11-27T09:17:33.725Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -862,27 +856,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:24:44.655Z",
+            "updatedAt": "2015-11-27T09:17:34.728Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:44 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:36 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/pablo_neruda
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/pablo_neruda
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Pablo Neruda"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -903,19 +897,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:45 GMT
+      - Fri, 27 Nov 2015 09:17:35 GMT
       Etag:
-      - '"5b6a5866e93eb6a2495f96e2468bf966"'
+      - '"75915efde81e868f6576076b93809d7e"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -923,39 +917,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1mOhp11gusg66Eq8eamKao
+      - content-api:3HbqSgwcy4qM6wciq6sO8K
       X-Powered-By:
       - Express
       Content-Length:
-      - '782'
+      - '729'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Pablo Neruda"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "pablo_neruda",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:24:45.665Z",
+            "createdAt": "2015-11-27T09:17:35.617Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -965,27 +955,27 @@ http_interactions:
                 "id": "author"
               }
             },
-            "updatedAt": "2015-11-18T15:24:45.665Z",
+            "updatedAt": "2015-11-27T09:17:35.617Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:45 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:37 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/pablo_neruda
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/pablo_neruda
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Pablo Neruda"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1006,19 +996,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:46 GMT
+      - Fri, 27 Nov 2015 09:17:36 GMT
       Etag:
-      - '"b4290730cd0c006d7c11b1dfc851be89"'
+      - '"4e508fabfdf21b0f9c7c97d1d6d3426a"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1026,38 +1016,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7EPEKpbwByE2MWq0oq4EOG
+      - content-api:2N5bNoeotOcyeQUueugYMc
       X-Powered-By:
       - Express
       Content-Length:
-      - '782'
+      - '729'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Pablo Neruda"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "pablo_neruda",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:24:45.665Z",
+            "createdAt": "2015-11-27T09:17:35.617Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -1068,27 +1054,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:24:46.505Z",
+            "updatedAt": "2015-11-27T09:17:36.596Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:46 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:38 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/zred3m25k5em/content_types/post
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/content_types/post
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1109,19 +1095,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:47 GMT
+      - Fri, 27 Nov 2015 09:17:37 GMT
       Etag:
-      - '"20969add1d9c21acae7220b7341e85c3"'
+      - '"15b6a7b0c82711ad95e0ea591a45d81a"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1129,7 +1115,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3oMZcRsgXuI6MEeyySiuUw
+      - content-api:1qXtYIjz3KQSE664oaiyO0
       X-Powered-By:
       - Express
       Content-Length:
@@ -1170,55 +1156,54 @@ http_interactions:
           "sys": {
             "id": "post",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:24:40.401Z",
+            "createdAt": "2015-11-27T09:17:28.093Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:24:41.217Z",
+            "firstPublishedAt": "2015-11-27T09:17:31.703Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:24:41.217Z",
+            "publishedAt": "2015-11-27T09:17:31.703Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T15:24:41.241Z",
+            "updatedAt": "2015-11-27T09:17:31.753Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:47 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:38 GMT
 - request:
-    method: post
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/inferno
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"Inferno"},"content":{"en-US":"Inferno
-        is the last book in Dan Brown''s collection..."},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"dan_brown"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1239,19 +1224,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:48 GMT
+      - Fri, 27 Nov 2015 09:17:38 GMT
       Etag:
-      - '"f0c9eb940b9ba3b2763a7996b2216404"'
+      - '"b09c0b0a49e0ea4e3fa4433582868fe8"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1259,51 +1244,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7M4yxwMEdUag4WUcIkIW4m
+      - content-api:5cYfR819UACwiMMOKiy2sK
       X-Powered-By:
       - Express
       Content-Length:
-      - '1041'
+      - '722'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "Inferno"
-            },
-            "content": {
-              "en-US": "Inferno is the last book in Dan Brown's collection..."
-            },
-            "author": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "dan_brown"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
-            "id": "2L6FsegUxiw22CMUY4qCQo",
+            "id": "inferno",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:24:48.188Z",
+            "createdAt": "2015-11-27T09:17:38.125Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -1313,28 +1282,27 @@ http_interactions:
                 "id": "post"
               }
             },
-            "updatedAt": "2015-11-18T15:24:48.188Z",
+            "updatedAt": "2015-11-27T09:17:38.125Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:48 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:39 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/2L6FsegUxiw22CMUY4qCQo
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/inferno
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"Inferno"},"content":{"en-US":"Inferno
-        is the last book in Dan Brown''s collection..."},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"dan_brown"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1355,19 +1323,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:49 GMT
+      - Fri, 27 Nov 2015 09:17:39 GMT
       Etag:
-      - '"be85ca00c78bd34bff0912e8f8fab523"'
+      - '"6c68b6746316d432284eadb78650ba34"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1375,50 +1343,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5Zq2Yoj7pYwEKIMI86M8mq
+      - content-api:3GCYd5gBcAswKaai48csW4
       X-Powered-By:
       - Express
       Content-Length:
-      - '1041'
+      - '722'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "Inferno"
-            },
-            "content": {
-              "en-US": "Inferno is the last book in Dan Brown's collection..."
-            },
-            "author": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "dan_brown"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
-            "id": "2L6FsegUxiw22CMUY4qCQo",
+            "id": "inferno",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:24:48.188Z",
+            "createdAt": "2015-11-27T09:17:38.125Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -1429,28 +1381,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:24:49.181Z",
+            "updatedAt": "2015-11-27T09:17:39.124Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:49 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:40 GMT
 - request:
-    method: post
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/alturas
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"Alturas de Macchu Picchu"},"content":{"en-US":"Alturas
-        de Macchu Picchu is one of Pablo Neruda''s most famous poetry books..."},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"pablo_neruda"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1471,19 +1422,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:50 GMT
+      - Fri, 27 Nov 2015 09:17:40 GMT
       Etag:
-      - '"e47a134decd7451c7556a57aab9bdeaf"'
+      - '"338672c9b31e46f332d5bc8498a50f45"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1491,51 +1442,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1BkSzCvMaQescOMycAOMM0
+      - content-api:ozrD86GR7EcyauqG82A6I
       X-Powered-By:
       - Express
       Content-Length:
-      - '1084'
+      - '722'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "Alturas de Macchu Picchu"
-            },
-            "content": {
-              "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
-            },
-            "author": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "pablo_neruda"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
-            "id": "gZfOUziDy88QIc4uo8o6G",
+            "id": "alturas",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:24:50.173Z",
+            "createdAt": "2015-11-27T09:17:40.029Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -1545,28 +1480,27 @@ http_interactions:
                 "id": "post"
               }
             },
-            "updatedAt": "2015-11-18T15:24:50.173Z",
+            "updatedAt": "2015-11-27T09:17:40.029Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:50 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:41 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/gZfOUziDy88QIc4uo8o6G
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/alturas
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"Alturas de Macchu Picchu"},"content":{"en-US":"Alturas
-        de Macchu Picchu is one of Pablo Neruda''s most famous poetry books..."},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"pablo_neruda"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1587,19 +1521,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:51 GMT
+      - Fri, 27 Nov 2015 09:17:41 GMT
       Etag:
-      - '"327d1f5d7c7692caca2c04dd7edcbdd8"'
+      - '"4af135b4f67c1211e9b036fd52d4061e"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1607,50 +1541,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3MVjo1SauQ4yOOM0UQYmwQ
+      - content-api:1cNfhM5scma4KmiSoKw48W
       X-Powered-By:
       - Express
       Content-Length:
-      - '1084'
+      - '722'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "Alturas de Macchu Picchu"
-            },
-            "content": {
-              "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
-            },
-            "author": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "pablo_neruda"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
-            "id": "gZfOUziDy88QIc4uo8o6G",
+            "id": "alturas",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:24:50.173Z",
+            "createdAt": "2015-11-27T09:17:40.029Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -1661,186 +1579,31 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:24:51.193Z",
+            "updatedAt": "2015-11-27T09:17:41.073Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:51 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:42 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries?content_type=author
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/dan_brown
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      Connection:
-      - close
-      Host:
-      - api.contentful.com
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
-      Access-Control-Allow-Methods:
-      - DELETE,GET,HEAD,POST,PUT,OPTIONS
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Etag
-      Access-Control-Max-Age:
-      - '1728000'
-      Cf-Space-Id:
-      - zred3m25k5em
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      Date:
-      - Wed, 18 Nov 2015 15:24:51 GMT
-      Etag:
-      - '"42546b9d9a8d210cf41b66e0deabf566"'
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Content-Type-Options:
-      - nosniff
-      X-Contentful-Request-Id:
-      - content-api:5ab4bWdKROMycaQw4UqAiY
-      X-Powered-By:
-      - Express
-      Content-Length:
-      - '1995'
-      Connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "sys": {
-            "type": "Array"
-          },
-          "total": 2,
-          "skip": 0,
-          "limit": 100,
-          "items": [
-            {
-              "fields": {
-                "name": {
-                  "en-US": "Dan Brown"
-                }
-              },
-              "sys": {
-                "id": "dan_brown",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:24:43.613Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "zred3m25k5em"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "author"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:24:44.713Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            },
-            {
-              "fields": {
-                "name": {
-                  "en-US": "Pablo Neruda"
-                }
-              },
-              "sys": {
-                "id": "pablo_neruda",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:24:45.665Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "zred3m25k5em"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "author"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:24:46.550Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:51 GMT
-- request:
-    method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/dan_brown/published
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RubyContentfulManagementGem/0.7.2
-      Authorization:
-      - Bearer foobar
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -1857,19 +1620,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:52 GMT
+      - Fri, 27 Nov 2015 09:17:41 GMT
       Etag:
-      - '"6e35a7814d98f05145a65ca155f6c2d4"'
+      - '"99a012d200fe1d3a45300eee8899076d"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1877,7 +1640,1820 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1PQcUFN3E4cy8O6SGS0m4A
+      - content-api:gAgIwLlFkWc0yuAAOKeMO
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '726'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "dan_brown",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:33.725Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:17:34.774Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:43 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/dan_brown
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Dan Brown"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:42 GMT
+      Etag:
+      - '"a4078d7618cfc3c1c5629e03b25c7566"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:41SjueXkoMQMaKKUIo0sCC
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '776'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Dan Brown"
+            }
+          },
+          "sys": {
+            "id": "dan_brown",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:33.725Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:17:42.593Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:44 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/dan_brown
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Dan Brown"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:43 GMT
+      Etag:
+      - '"69f43abf82bc3eff25d632724f4e341e"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:6Cnm13qfSMWW8gIMOaaGYo
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '776'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Dan Brown"
+            }
+          },
+          "sys": {
+            "id": "dan_brown",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:33.725Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:43.593Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:45 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/dan_brown
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:44 GMT
+      Etag:
+      - '"eb75c0f45b7dfe21fff92907c00aaf26"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:6yg9qQjPMI4uM4i0S0Mg08
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '776'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Dan Brown"
+            }
+          },
+          "sys": {
+            "id": "dan_brown",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:33.725Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:43.638Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:45 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/pablo_neruda
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:44 GMT
+      Etag:
+      - '"499e42514a4b1873021c1cbc7e400123"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:2X6nN4cHi8occAsawqSCqw
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '729'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "pablo_neruda",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:35.617Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:17:36.642Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:46 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/pablo_neruda
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Pablo Neruda"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:45 GMT
+      Etag:
+      - '"58faa7ecd04f535aa9cb33c1ac1a5096"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1RzFhJmfo8AECm8Eyg2eQA
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '782'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Pablo Neruda"
+            }
+          },
+          "sys": {
+            "id": "pablo_neruda",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:35.617Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:17:45.648Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:47 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/pablo_neruda
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Pablo Neruda"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:46 GMT
+      Etag:
+      - '"10ae5bdadcab4e9d3f47d49de79f1f91"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:euDGoHDFBKkQYKIKOk0Wg
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '782'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Pablo Neruda"
+            }
+          },
+          "sys": {
+            "id": "pablo_neruda",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:35.617Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:46.567Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:48 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/pablo_neruda
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:47 GMT
+      Etag:
+      - '"ff69fb3acf55ee6be578bd6a3ed946c2"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:2SKt9JQ2ukqQ2As0GKY22m
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '782'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Pablo Neruda"
+            }
+          },
+          "sys": {
+            "id": "pablo_neruda",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:35.617Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:46.613Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:48 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/inferno
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:47 GMT
+      Etag:
+      - '"482dc456c42987d12be9e91f56129fa4"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4MlaCjsMJ2Oc2ECII04s4Y
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '722'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "inferno",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:38.125Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:17:39.170Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:49 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/inferno
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"Inferno"},"content":{"en-US":"Inferno
+        is the last book in Dan Brown''s collection..."},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"dan_brown"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:48 GMT
+      Etag:
+      - '"ec11d7491c913b43fc9a1263744f6baf"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:6eGTsjBNzGG0iqUuMugeC6
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1026'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Inferno"
+            },
+            "content": {
+              "en-US": "Inferno is the last book in Dan Brown's collection..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "dan_brown"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "inferno",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:38.125Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:17:48.667Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:50 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/inferno
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"Inferno"},"content":{"en-US":"Inferno
+        is the last book in Dan Brown''s collection..."},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"dan_brown"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:49 GMT
+      Etag:
+      - '"36d22c4b3413a4b880f28d30d2abea2f"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3qzjr3ziDSekg20i42AcoW
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1026'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Inferno"
+            },
+            "content": {
+              "en-US": "Inferno is the last book in Dan Brown's collection..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "dan_brown"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "inferno",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:38.125Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:49.597Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:51 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/inferno
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:50 GMT
+      Etag:
+      - '"8aebf0a29878a4fd3f7cd516877d3219"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:61UYRlFLoc00S0oE60igAy
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1026'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Inferno"
+            },
+            "content": {
+              "en-US": "Inferno is the last book in Dan Brown's collection..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "dan_brown"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "inferno",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:38.125Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:49.647Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:51 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/alturas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:50 GMT
+      Etag:
+      - '"85a98ca5480087765ee656ffa13874d1"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:nbksdn3hGo4MgcgCYsAu6
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '722'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "alturas",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:40.029Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:17:41.119Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:52 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/alturas
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"Alturas de Macchu Picchu"},"content":{"en-US":"Alturas
+        de Macchu Picchu is one of Pablo Neruda''s most famous poetry books..."},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"pablo_neruda"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:51 GMT
+      Etag:
+      - '"2455460d657a7235c8f44c2eef626bcd"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5652RgPMTSw4GqSuiWm6I6
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1070'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Alturas de Macchu Picchu"
+            },
+            "content": {
+              "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "pablo_neruda"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "alturas",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:40.029Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:17:51.693Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:53 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/alturas
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"Alturas de Macchu Picchu"},"content":{"en-US":"Alturas
+        de Macchu Picchu is one of Pablo Neruda''s most famous poetry books..."},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"pablo_neruda"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:52 GMT
+      Etag:
+      - '"31d266d408fe2ee554880de6f776df77"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:11FNCPvsJKSm0cYUY6qU86
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1070'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Alturas de Macchu Picchu"
+            },
+            "content": {
+              "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "pablo_neruda"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "alturas",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:40.029Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:52.644Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:54 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/alturas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:53 GMT
+      Etag:
+      - '"e7b8579e3904109b61cb3bf9ccdb8337"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5SdLmCaZHygcYQw8cEyeGI
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1070'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Alturas de Macchu Picchu"
+            },
+            "content": {
+              "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "pablo_neruda"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "alturas",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:40.029Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:52.691Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:54 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/dan_brown
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:53 GMT
+      Etag:
+      - '"eb75c0f45b7dfe21fff92907c00aaf26"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5LkCdVdwYg2cS6aeMoy2ci
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '776'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Dan Brown"
+            }
+          },
+          "sys": {
+            "id": "dan_brown",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:33.725Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:43.638Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:55 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/dan_brown/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:54 GMT
+      Etag:
+      - '"60cad31981575c4e5746a07368e42bef"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:713YRC3ZPqoC0OqeyySSWA
       X-Powered-By:
       - Express
       Content-Length:
@@ -1896,19 +3472,19 @@ http_interactions:
           "sys": {
             "id": "dan_brown",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:24:43.613Z",
+            "createdAt": "2015-11-27T09:17:33.725Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -1918,45 +3494,43 @@ http_interactions:
                 "id": "author"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:24:52.659Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:17:54.556Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:24:52.659Z",
+            "firstPublishedAt": "2015-11-27T09:17:54.556Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:24:52.659Z",
+            "publishedAt": "2015-11-27T09:17:54.556Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:52 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:56 GMT
 - request:
-    method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/pablo_neruda/published
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/pablo_neruda
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -1973,19 +3547,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:53 GMT
+      - Fri, 27 Nov 2015 09:17:55 GMT
       Etag:
-      - '"96c6bdaaa35a3bb6d10f3c537ebed30b"'
+      - '"ff69fb3acf55ee6be578bd6a3ed946c2"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1993,7 +3567,112 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3FtXHI3FSw6MW8mAAe0ska
+      - content-api:3MXv7phoDuQeoAok0mG4SU
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '782'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Pablo Neruda"
+            }
+          },
+          "sys": {
+            "id": "pablo_neruda",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:35.617Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:46.613Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:56 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/pablo_neruda/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:56 GMT
+      Etag:
+      - '"6552197be180a6d46725d06a9ec36af3"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:2BpWQurwzWW0KeoU222OWE
       X-Powered-By:
       - Express
       Content-Length:
@@ -2012,19 +3691,19 @@ http_interactions:
           "sys": {
             "id": "pablo_neruda",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:24:45.665Z",
+            "createdAt": "2015-11-27T09:17:35.617Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -2034,222 +3713,43 @@ http_interactions:
                 "id": "author"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:24:53.618Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:17:56.044Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:24:53.618Z",
+            "firstPublishedAt": "2015-11-27T09:17:56.044Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:24:53.618Z",
+            "publishedAt": "2015-11-27T09:17:56.044Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:53 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:57 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries?content_type=post
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/inferno
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      Connection:
-      - close
-      Host:
-      - api.contentful.com
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
-      Access-Control-Allow-Methods:
-      - DELETE,GET,HEAD,POST,PUT,OPTIONS
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Etag
-      Access-Control-Max-Age:
-      - '1728000'
-      Cf-Space-Id:
-      - zred3m25k5em
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      Date:
-      - Wed, 18 Nov 2015 15:24:54 GMT
-      Etag:
-      - '"1a207c8e5838fcc034b8609d11203f98"'
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Content-Type-Options:
-      - nosniff
-      X-Contentful-Request-Id:
-      - content-api:2mpN9zKVMY2oII0CeQqIqC
-      X-Powered-By:
-      - Express
-      Content-Length:
-      - '2658'
-      Connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "sys": {
-            "type": "Array"
-          },
-          "total": 2,
-          "skip": 0,
-          "limit": 100,
-          "items": [
-            {
-              "fields": {
-                "title": {
-                  "en-US": "Alturas de Macchu Picchu"
-                },
-                "content": {
-                  "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
-                },
-                "author": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Entry",
-                      "id": "pablo_neruda"
-                    }
-                  }
-                }
-              },
-              "sys": {
-                "id": "gZfOUziDy88QIc4uo8o6G",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:24:50.173Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "zred3m25k5em"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "post"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:24:51.250Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            },
-            {
-              "fields": {
-                "title": {
-                  "en-US": "Inferno"
-                },
-                "content": {
-                  "en-US": "Inferno is the last book in Dan Brown's collection..."
-                },
-                "author": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Entry",
-                      "id": "dan_brown"
-                    }
-                  }
-                }
-              },
-              "sys": {
-                "id": "2L6FsegUxiw22CMUY4qCQo",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:24:48.188Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "zred3m25k5em"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "post"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:24:49.226Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:54 GMT
-- request:
-    method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/gZfOUziDy88QIc4uo8o6G/published
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RubyContentfulManagementGem/0.7.2
-      Authorization:
-      - Bearer foobar
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -2266,19 +3766,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - zred3m25k5em
+      - xrfaz3bfkml6
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:55 GMT
+      - Fri, 27 Nov 2015 09:17:56 GMT
       Etag:
-      - '"13468f94005bf16ef3c8e109d05bd764"'
+      - '"8aebf0a29878a4fd3f7cd516877d3219"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2286,139 +3786,11 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6mxOeIBDKoq4SccoAyQ0Q
+      - content-api:3XGsjUd4zCmYMGwKU2KUsk
       X-Powered-By:
       - Express
       Content-Length:
-      - '1379'
-      Connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "fields": {
-            "title": {
-              "en-US": "Alturas de Macchu Picchu"
-            },
-            "content": {
-              "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
-            },
-            "author": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "pablo_neruda"
-                }
-              }
-            }
-          },
-          "sys": {
-            "id": "gZfOUziDy88QIc4uo8o6G",
-            "type": "Entry",
-            "createdAt": "2015-11-18T15:24:50.173Z",
-            "createdBy": {
-              "sys": {
-                "type": "Link",
-                "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
-              }
-            },
-            "space": {
-              "sys": {
-                "type": "Link",
-                "linkType": "Space",
-                "id": "zred3m25k5em"
-              }
-            },
-            "contentType": {
-              "sys": {
-                "type": "Link",
-                "linkType": "ContentType",
-                "id": "post"
-              }
-            },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:24:55.198Z",
-            "updatedBy": {
-              "sys": {
-                "type": "Link",
-                "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
-              }
-            },
-            "firstPublishedAt": "2015-11-18T15:24:55.198Z",
-            "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:24:55.198Z",
-            "publishedBy": {
-              "sys": {
-                "type": "Link",
-                "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
-              }
-            },
-            "publishedVersion": 2
-          }
-        }
-    http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:55 GMT
-- request:
-    method: put
-    uri: https://api.contentful.com/spaces/zred3m25k5em/entries/2L6FsegUxiw22CMUY4qCQo/published
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RubyContentfulManagementGem/0.7.2
-      Authorization:
-      - Bearer foobar
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
-      Content-Length:
-      - '0'
-      Connection:
-      - close
-      Host:
-      - api.contentful.com
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
-      Access-Control-Allow-Methods:
-      - DELETE,GET,HEAD,POST,PUT,OPTIONS
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Etag
-      Access-Control-Max-Age:
-      - '1728000'
-      Cf-Space-Id:
-      - zred3m25k5em
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      Date:
-      - Wed, 18 Nov 2015 15:24:56 GMT
-      Etag:
-      - '"a36bfe3f023167700d015855ff17e503"'
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Content-Type-Options:
-      - nosniff
-      X-Contentful-Request-Id:
-      - content-api:MTr1TdAKA0uicEqEEqoSu
-      X-Powered-By:
-      - Express
-      Content-Length:
-      - '1336'
+      - '1026'
       Connection:
       - Close
     body:
@@ -2443,21 +3815,21 @@ http_interactions:
             }
           },
           "sys": {
-            "id": "2L6FsegUxiw22CMUY4qCQo",
+            "id": "inferno",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:24:48.188Z",
+            "createdAt": "2015-11-27T09:17:38.125Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "zred3m25k5em"
+                "id": "xrfaz3bfkml6"
               }
             },
             "contentType": {
@@ -2467,40 +3839,400 @@ http_interactions:
                 "id": "post"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:24:56.048Z",
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:49.647Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:58 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/inferno/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:57 GMT
+      Etag:
+      - '"7ce5091c77fb53d25178b9cb54aa34f1"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:548Y3n1SIUWkUiIUImUE0C
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1321'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Inferno"
+            },
+            "content": {
+              "en-US": "Inferno is the last book in Dan Brown's collection..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "dan_brown"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "inferno",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:38.125Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:24:56.048Z",
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 5,
+            "updatedAt": "2015-11-27T09:17:57.526Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "firstPublishedAt": "2015-11-27T09:17:57.526Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:24:56.048Z",
+            "publishedAt": "2015-11-27T09:17:57.526Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:56 GMT
+  recorded_at: Fri, 27 Nov 2015 09:17:59 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/alturas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:58 GMT
+      Etag:
+      - '"e7b8579e3904109b61cb3bf9ccdb8337"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:2BRLvjrJzCoMkskyiECWQq
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1070'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Alturas de Macchu Picchu"
+            },
+            "content": {
+              "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "pablo_neruda"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "alturas",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:40.029Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:17:52.691Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:17:59 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/entries/alturas/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - xrfaz3bfkml6
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:17:59 GMT
+      Etag:
+      - '"346413e8237fc122dd209b76d7662389"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4B2KY6f2O4wGiIAQiyEgAG
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1365'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Alturas de Macchu Picchu"
+            },
+            "content": {
+              "en-US": "Alturas de Macchu Picchu is one of Pablo Neruda's most famous poetry books..."
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "pablo_neruda"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "alturas",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:17:40.029Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "xrfaz3bfkml6"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "post"
+              }
+            },
+            "version": 5,
+            "updatedAt": "2015-11-27T09:17:58.942Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "firstPublishedAt": "2015-11-27T09:17:58.942Z",
+            "publishedCounter": 1,
+            "publishedAt": "2015-11-27T09:17:58.942Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "publishedVersion": 4
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:18:00 GMT
 - request:
     method: post
-    uri: https://api.contentful.com/spaces/zred3m25k5em/api_keys
+    uri: https://api.contentful.com/spaces/xrfaz3bfkml6/api_keys
     body:
       encoding: UTF-8
       string: '{"name":"Bootstrap Token","description":"Created with ''contentful_bootstrap.rb
         v2.0.2''"}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2521,7 +4253,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -2531,11 +4263,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:57 GMT
+      - Fri, 27 Nov 2015 09:17:59 GMT
       Etag:
-      - '"d5f9e8dbad4aea0d52009db800edbe99"'
+      - '"25db0723a382f38c7bf841c26ea0a5c1"'
       Location:
-      - https://api.contentful.com/spaces/zred3m25k5em/api_keys/3uVgEJKwdRTyw8iVUpttC0
+      - https://api.contentful.com/spaces/xrfaz3bfkml6/api_keys/5h5R69Bct4MXw60JvV1EFr
       Server:
       - nginx
       Status:
@@ -2545,7 +4277,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - 0b5-124658898
+      - 9e1-621575938
       Content-Length:
       - '954'
       Connection:
@@ -2556,35 +4288,35 @@ http_interactions:
         {
           "sys":{
             "type":"ApiKey",
-            "id":"3uVgEJKwdRTyw8iVUpttC0",
+            "id":"5h5R69Bct4MXw60JvV1EFr",
             "version":0,
             "space":{
               "sys":{
                 "type":"Link",
                 "linkType":"Space",
-                "id":"zred3m25k5em"
+                "id":"xrfaz3bfkml6"
               }
             },
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-18T15:24:57Z",
+            "createdAt":"2015-11-27T09:17:59Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-18T15:24:57Z"
+            "updatedAt":"2015-11-27T09:17:59Z"
           },
           "name":"Bootstrap Token",
           "description":"Created with 'contentful_bootstrap.rb v2.0.2'",
-          "accessToken":"1c1521741f61d50bfc03e79d359d3832c4890af0999fceb64b5bfd88bfd234f5",
+          "accessToken":"134ef5abc54077f89a60f813d01bbd0e4d8c16f5286809380a0ca72431429b0b",
           "policies":[
             {
               "effect":"allow",
@@ -2595,11 +4327,11 @@ http_interactions:
             "sys":{
               "type":"Link",
               "linkType":"PreviewApiKey",
-              "id":"3uWzHynd1juIxO85vmTtkY"
+              "id":"5h6QIethJjQ3GuAiYHnTQB"
             }
           }
         }
 
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:57 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Fri, 27 Nov 2015 09:18:01 GMT
+recorded_with: VCR 3.0.0

--- a/spec/fixtures/vcr_fixtures/create_space_with_catalogue_template.yml
+++ b/spec/fixtures/vcr_fixtures/create_space_with_catalogue_template.yml
@@ -8,11 +8,13 @@ http_interactions:
       string: '{"name":"catalogue_space","defaultLocale":"en-US"}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
+      X-Contentful-Organization:
+      - 1PLOOEmTI2S1NYald2TemO
       Connection:
       - close
       Host:
@@ -29,7 +31,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -39,11 +41,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:31 GMT
+      - Fri, 27 Nov 2015 09:04:26 GMT
       Etag:
-      - '"bc462fdc0b059fc209b362edd2daf9bf"'
+      - '"d8526c2b3380b74ed86489e4fdcf1f9c"'
       Location:
-      - https://api.contentful.com/spaces/x4aalb1l82h7
+      - https://api.contentful.com/spaces/rlql1v35lr9w
       Server:
       - nginx
       Status:
@@ -53,7 +55,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - 9e1-615651262
+      - 9e1-621570451
       Content-Length:
       - '458'
       Connection:
@@ -64,40 +66,40 @@ http_interactions:
         {
           "sys":{
             "type":"Space",
-            "id":"x4aalb1l82h7",
+            "id":"rlql1v35lr9w",
             "version":1,
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-18T15:25:30Z",
+            "createdAt":"2015-11-27T09:04:24Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-18T15:25:30Z"
+            "updatedAt":"2015-11-27T09:04:24Z"
           },
           "name":"catalogue_space"
         }
 
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:30 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:28 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/brand
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/brand
     body:
       encoding: UTF-8
       string: '{"displayField":"name","name":"Brand","description":null,"fields":[{"id":"name","name":"Company
         Name","type":"Symbol"},{"id":"website","name":"Website","type":"Symbol"},{"id":"logo","name":"Logo","type":"Link","linkType":"Asset"}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -116,19 +118,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:32 GMT
+      - Fri, 27 Nov 2015 09:04:30 GMT
       Etag:
-      - '"b03d2e249ffcfcfac0d5f57965dc687b"'
+      - '"2fc22af1a98e374d09854ad46d505b01"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -136,7 +138,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4Rx5qxEBja8I0cQu0O4G8s
+      - content-api:59chMdDwFq6eY8GmomIqo2
       X-Powered-By:
       - Express
       Content-Length:
@@ -178,42 +180,42 @@ http_interactions:
             "id": "brand",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:32.401Z",
+            "createdAt": "2015-11-27T09:04:30.361Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:32.401Z",
+            "updatedAt": "2015-11-27T09:04:30.361Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:32 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:32 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/brand/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/brand/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -236,19 +238,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:33 GMT
+      - Fri, 27 Nov 2015 09:04:34 GMT
       Etag:
-      - '"6934ebec48cf85fde37bae7e3e3e8191"'
+      - '"52cf7e358750c9cd7d7d666b62c4d995"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -256,7 +258,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7j4ZU9adtSuwmA0ooK2QWa
+      - content-api:2DObY5xWXmsAYKI60KwqIu
       X-Powered-By:
       - Express
       Content-Length:
@@ -297,54 +299,54 @@ http_interactions:
           "sys": {
             "id": "brand",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:32.401Z",
+            "createdAt": "2015-11-27T09:04:30.361Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:33.177Z",
+            "updatedAt": "2015-11-27T09:04:33.908Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:33.177Z",
+            "firstPublishedAt": "2015-11-27T09:04:33.908Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:33.177Z",
+            "publishedAt": "2015-11-27T09:04:33.908Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:33 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:36 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/category
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/category
     body:
       encoding: UTF-8
       string: '{"displayField":"title","name":"Category","description":null,"fields":[{"id":"title","name":"Title","type":"Symbol"},{"id":"description","name":"Description","type":"Text"},{"id":"icon","name":"Icon","type":"Link","linkType":"Asset"}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -363,19 +365,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:34 GMT
+      - Fri, 27 Nov 2015 09:04:38 GMT
       Etag:
-      - '"4f34eca4c56abfaa0d5505f8373e22a5"'
+      - '"b4e69b5fc5de4d58ee8bf64f5e9323e2"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -383,7 +385,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2kiDM2jMvyqU8GS2SMic8E
+      - content-api:2gOaAVl6JGw20Q04I6MQwM
       X-Powered-By:
       - Express
       Content-Length:
@@ -425,42 +427,42 @@ http_interactions:
             "id": "category",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:34.733Z",
+            "createdAt": "2015-11-27T09:04:38.497Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:34.733Z",
+            "updatedAt": "2015-11-27T09:04:38.497Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:34 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:40 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/category/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/category/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -483,19 +485,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:35 GMT
+      - Fri, 27 Nov 2015 09:04:39 GMT
       Etag:
-      - '"291a3adcb5cad51ea1b9d5d437d7ec67"'
+      - '"dc9e2bef4a15917aff5820b82a21c968"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -503,7 +505,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6uN4F2KtSoG4C06K48yO8y
+      - content-api:9uL3bUWltm0YgGASqYsgo
       X-Powered-By:
       - Express
       Content-Length:
@@ -544,55 +546,55 @@ http_interactions:
           "sys": {
             "id": "category",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:34.733Z",
+            "createdAt": "2015-11-27T09:04:38.497Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:35.508Z",
+            "updatedAt": "2015-11-27T09:04:39.235Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:35.508Z",
+            "firstPublishedAt": "2015-11-27T09:04:39.235Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:35.508Z",
+            "publishedAt": "2015-11-27T09:04:39.235Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:35 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:41 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/product
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/product
     body:
       encoding: UTF-8
       string: '{"displayField":"name","name":"Product","description":null,"fields":[{"id":"name","name":"name","type":"Symbol"},{"id":"description","name":"Description","type":"Text"},{"id":"image","name":"Image","type":"Link","linkType":"Asset"},{"id":"brand","name":"Brand","type":"Link","linkType":"Entry"},{"id":"category","name":"Category","type":"Link","linkType":"Entry"},{"id":"url","name":"Available
         at","type":"Symbol"}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -611,19 +613,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:37 GMT
+      - Fri, 27 Nov 2015 09:04:41 GMT
       Etag:
-      - '"6e58d84586e7ab2acf1962dfb5f35e43"'
+      - '"db47b72ff8e9dcd4a2ae27d4a5ccb0b0"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -631,7 +633,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7ttBKfkcs8kee8AkgqOIeO
+      - content-api:fbruwAoWHeueKmKkwCoYU
       X-Powered-By:
       - Express
       Content-Length:
@@ -696,42 +698,42 @@ http_interactions:
             "id": "product",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:37.517Z",
+            "createdAt": "2015-11-27T09:04:41.101Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:37.517Z",
+            "updatedAt": "2015-11-27T09:04:41.101Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:37 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:42 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/product/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/product/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -754,19 +756,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:38 GMT
+      - Fri, 27 Nov 2015 09:04:42 GMT
       Etag:
-      - '"23d2ccd617a7ed6382b00efc4cc7a5d4"'
+      - '"2eb655365adb7894392b719bf7c23e25"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -774,7 +776,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1FaCDFYryAUmuyOmc8AIaq
+      - content-api:4dcmghPxOEWE2oWQEsq4sS
       X-Powered-By:
       - Express
       Content-Length:
@@ -838,54 +840,54 @@ http_interactions:
           "sys": {
             "id": "product",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:37.517Z",
+            "createdAt": "2015-11-27T09:04:41.101Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:38.245Z",
+            "updatedAt": "2015-11-27T09:04:41.797Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:38.245Z",
+            "firstPublishedAt": "2015-11-27T09:04:41.797Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:38.245Z",
+            "publishedAt": "2015-11-27T09:04:41.797Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:38 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:43 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/playsam_image
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/playsam_image
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Playsam"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"playsam_image.jpg","upload":"https://images.contentful.com/liicpxzmg1q0/4zj1ZOfHgQ8oqgaSKm4Qo2/3be82d54d45b5297e951aee9baf920da/playsam.jpg?h=250&"}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -904,19 +906,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:39 GMT
+      - Fri, 27 Nov 2015 09:04:43 GMT
       Etag:
-      - '"08341415340b0e7c0b1b598a19cffb4a"'
+      - '"aad9fbe68c4f7395c45efd422bdc609d"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -924,7 +926,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:ww1qJDlSjA6Ykc6IS8AOS
+      - content-api:1v2p8zZA68E4OiOcE4G2is
       X-Powered-By:
       - Express
       Content-Length:
@@ -954,42 +956,42 @@ http_interactions:
             "id": "playsam_image",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:39.529Z",
+            "createdAt": "2015-11-27T09:04:43.188Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:39.529Z",
+            "updatedAt": "2015-11-27T09:04:43.188Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:39 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:44 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/playsam_image/files/en-US/process
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/playsam_image/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1012,17 +1014,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:40 GMT
+      - Fri, 27 Nov 2015 09:04:43 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1030,7 +1032,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:688eP9Cff2QcQIUq6Uo8Gc
+      - content-api:vqqrVqY2tiUkwaKq0MokO
       X-Powered-By:
       - Express
       Connection:
@@ -1039,16 +1041,16 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:40 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:45 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/playsam_image
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/playsam_image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1069,19 +1071,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:40 GMT
+      - Fri, 27 Nov 2015 09:04:44 GMT
       Etag:
-      - '"70acd6a3f4b7e19229fdcdbf6ae8efbb"'
+      - '"6b1f78745497cef1929e95837e696115"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1089,7 +1091,113 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2WGiskDnMAio0yWs6aqgOs
+      - content-api:5AKMP41XnUk6cqQKGOCGqo
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '956'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Playsam"
+            },
+            "description": {
+              "en-US": null
+            },
+            "file": {
+              "en-US": {
+                "contentType": "image/jpeg",
+                "fileName": "playsam_image.jpg",
+                "upload": "https://images.contentful.com/liicpxzmg1q0/4zj1ZOfHgQ8oqgaSKm4Qo2/3be82d54d45b5297e951aee9baf920da/playsam.jpg?h=250&"
+              }
+            }
+          },
+          "sys": {
+            "id": "playsam_image",
+            "type": "Asset",
+            "createdAt": "2015-11-27T09:04:43.188Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "version": 1,
+            "updatedAt": "2015-11-27T09:04:43.233Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:46 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/playsam_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:46 GMT
+      Etag:
+      - '"bbadea5d1db3e9b6cbf77ff0461fccf9"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:p761oMfF5uWwk44IMoSGI
       X-Powered-By:
       - Express
       Content-Length:
@@ -1118,50 +1226,50 @@ http_interactions:
                   },
                   "size": 6062
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/playsam_image/14a8182fbb061882093ccaa667ed2a14/playsam_image.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/playsam_image/364e28713a7ff1f0a635461a79acb016/playsam_image.jpg"
               }
             }
           },
           "sys": {
             "id": "playsam_image",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:39.529Z",
+            "createdAt": "2015-11-27T09:04:43.188Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:40.859Z",
+            "updatedAt": "2015-11-27T09:04:44.607Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:40 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:47 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/playsam_image/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/playsam_image/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1184,19 +1292,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:41 GMT
+      - Fri, 27 Nov 2015 09:04:46 GMT
       Etag:
-      - '"553c3731a2aff57c0fdac14d5c8d9696"'
+      - '"d0a1bad35e5f19d683c4edcc7898f66a"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1204,7 +1312,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1IlF0OyIXOSakaowCco4Uk
+      - content-api:4U9PDbmWcokQCqqYy4cIO0
       X-Powered-By:
       - Express
       Content-Length:
@@ -1233,61 +1341,61 @@ http_interactions:
                   },
                   "size": 6062
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/playsam_image/14a8182fbb061882093ccaa667ed2a14/playsam_image.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/playsam_image/364e28713a7ff1f0a635461a79acb016/playsam_image.jpg"
               }
             }
           },
           "sys": {
             "id": "playsam_image",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:39.529Z",
+            "createdAt": "2015-11-27T09:04:43.188Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:41.680Z",
+            "updatedAt": "2015-11-27T09:04:46.741Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:41.679Z",
+            "firstPublishedAt": "2015-11-27T09:04:46.741Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:41.679Z",
+            "publishedAt": "2015-11-27T09:04:46.741Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:41 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:48 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/normann_image
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/normann_image
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Normann"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"normann_image.jpg","upload":"https://images.contentful.com/liicpxzmg1q0/3wtvPBbBjiMKqKKga8I2Cu/75c7c92f38f7953a741591d215ad61d4/zJYzDlGk.jpeg?h=250&"}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1306,19 +1414,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:43 GMT
+      - Fri, 27 Nov 2015 09:04:47 GMT
       Etag:
-      - '"f924e6431354b1388824723c65060cdc"'
+      - '"d34c38fd16eb5a8a3e4e4491e537701b"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1326,7 +1434,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3FY3jMvMtO66gM6EQYIYMc
+      - content-api:3C59bgDnPWMew2Ywak0IKG
       X-Powered-By:
       - Express
       Content-Length:
@@ -1356,42 +1464,42 @@ http_interactions:
             "id": "normann_image",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:42.989Z",
+            "createdAt": "2015-11-27T09:04:47.760Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:42.989Z",
+            "updatedAt": "2015-11-27T09:04:47.760Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:42 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:49 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/normann_image/files/en-US/process
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/normann_image/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1414,17 +1522,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:43 GMT
+      - Fri, 27 Nov 2015 09:04:48 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1432,7 +1540,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4wQx3IvZB6EAse6SsyGMWU
+      - content-api:5X8AmI0bHGWUqO0ome8yiM
       X-Powered-By:
       - Express
       Connection:
@@ -1441,16 +1549,16 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:43 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:50 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/normann_image
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/normann_image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1471,19 +1579,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:44 GMT
+      - Fri, 27 Nov 2015 09:04:49 GMT
       Etag:
-      - '"fbcf91da681ec5bea4650da538baf2d8"'
+      - '"0ff499814fa082c179cc222740c8feac"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1491,7 +1599,113 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1MIpPiRuc0OKIKoCmawu8Y
+      - content-api:5Q0q8QVji0UQgY4mSEKmQM
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '958'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Normann"
+            },
+            "description": {
+              "en-US": null
+            },
+            "file": {
+              "en-US": {
+                "contentType": "image/jpeg",
+                "fileName": "normann_image.jpg",
+                "upload": "https://images.contentful.com/liicpxzmg1q0/3wtvPBbBjiMKqKKga8I2Cu/75c7c92f38f7953a741591d215ad61d4/zJYzDlGk.jpeg?h=250&"
+              }
+            }
+          },
+          "sys": {
+            "id": "normann_image",
+            "type": "Asset",
+            "createdAt": "2015-11-27T09:04:47.760Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "version": 1,
+            "updatedAt": "2015-11-27T09:04:47.805Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:50 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/normann_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:50 GMT
+      Etag:
+      - '"4567d59bdc2c45e76ab408ad6f7599fc"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5kp71PmC0EQgIKQeK0YSqC
       X-Powered-By:
       - Express
       Content-Length:
@@ -1520,50 +1734,50 @@ http_interactions:
                   },
                   "size": 7856
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/normann_image/89cac9e77243074ba788dbe59175fa2c/normann_image.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/normann_image/4c178f3153c5f82bc3f4b819a0566427/normann_image.jpg"
               }
             }
           },
           "sys": {
             "id": "normann_image",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:42.989Z",
+            "createdAt": "2015-11-27T09:04:47.760Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:43.966Z",
+            "updatedAt": "2015-11-27T09:04:49.186Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:44 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:52 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/normann_image/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/normann_image/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1586,19 +1800,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:45 GMT
+      - Fri, 27 Nov 2015 09:04:51 GMT
       Etag:
-      - '"f6cd1cca5d533a0839769b032443bc45"'
+      - '"db86f5758e70b4f8baf1343f38a3c77c"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1606,7 +1820,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4xwpeHYdD2K0sma82MSQW4
+      - content-api:1TBUdga6UosgAGAEey2sUY
       X-Powered-By:
       - Express
       Content-Length:
@@ -1635,61 +1849,61 @@ http_interactions:
                   },
                   "size": 7856
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/normann_image/89cac9e77243074ba788dbe59175fa2c/normann_image.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/normann_image/4c178f3153c5f82bc3f4b819a0566427/normann_image.jpg"
               }
             }
           },
           "sys": {
             "id": "normann_image",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:42.989Z",
+            "createdAt": "2015-11-27T09:04:47.760Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:45.306Z",
+            "updatedAt": "2015-11-27T09:04:51.274Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:45.306Z",
+            "firstPublishedAt": "2015-11-27T09:04:51.274Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:45.306Z",
+            "publishedAt": "2015-11-27T09:04:51.274Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:45 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:53 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/toy_image
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_image
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Toys"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"toy_image.jpg","upload":"https://images.contentful.com/liicpxzmg1q0/6t4HKjytPi0mYgs240wkG/866ef53a11af9c6bf5f3808a8ce1aab2/toys_512pxGREY.png?h=250&"}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1708,19 +1922,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:46 GMT
+      - Fri, 27 Nov 2015 09:04:52 GMT
       Etag:
-      - '"319a952319bffeca5109e5e7a3628e50"'
+      - '"34e6dcf73dbdf5132329d659815bcb01"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1728,7 +1942,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4IjkQtJwLCCaaqGgiAQyY0
+      - content-api:7lkuzEN8cwOsQkkqIyg8Mw
       X-Powered-By:
       - Express
       Content-Length:
@@ -1758,42 +1972,42 @@ http_interactions:
             "id": "toy_image",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:46.429Z",
+            "createdAt": "2015-11-27T09:04:52.328Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:46.429Z",
+            "updatedAt": "2015-11-27T09:04:52.328Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:46 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:54 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/toy_image/files/en-US/process
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_image/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1816,17 +2030,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:47 GMT
+      - Fri, 27 Nov 2015 09:04:53 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1834,7 +2048,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1kViqWcDtOAOookCKaUksa
+      - content-api:5IXsFARvmEKuOIq6OCYOq0
       X-Powered-By:
       - Express
       Connection:
@@ -1843,16 +2057,16 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:47 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:54 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/toy_image
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1873,19 +2087,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:47 GMT
+      - Fri, 27 Nov 2015 09:04:53 GMT
       Etag:
-      - '"7ce004b9a74734dba5194c5a789e3bbb"'
+      - '"14cd17970da144515205bdb616a333bb"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1893,7 +2107,113 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4djhyecbbOgwWOok68IQqU
+      - content-api:5Xs7WZuN8WwmqWY0qW2aSa
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '951'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Toys"
+            },
+            "description": {
+              "en-US": null
+            },
+            "file": {
+              "en-US": {
+                "contentType": "image/jpeg",
+                "fileName": "toy_image.jpg",
+                "upload": "https://images.contentful.com/liicpxzmg1q0/6t4HKjytPi0mYgs240wkG/866ef53a11af9c6bf5f3808a8ce1aab2/toys_512pxGREY.png?h=250&"
+              }
+            }
+          },
+          "sys": {
+            "id": "toy_image",
+            "type": "Asset",
+            "createdAt": "2015-11-27T09:04:52.328Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "version": 1,
+            "updatedAt": "2015-11-27T09:04:52.372Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:55 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:55 GMT
+      Etag:
+      - '"b2e8258d18c5b9909ee1ed8a7e05b326"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:52qf1NndKomIY4gGMIiE00
       X-Powered-By:
       - Express
       Content-Length:
@@ -1922,50 +2242,50 @@ http_interactions:
                   },
                   "size": 6744
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/toy_image/198505151a9e451a0f3be3c51108e89c/toy_image.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/toy_image/ebbc3797b3895a4687cdac25abe478c1/toy_image.jpg"
               }
             }
           },
           "sys": {
             "id": "toy_image",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:46.429Z",
+            "createdAt": "2015-11-27T09:04:52.328Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:47.638Z",
+            "updatedAt": "2015-11-27T09:04:53.730Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:47 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:57 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/toy_image/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_image/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1988,19 +2308,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:48 GMT
+      - Fri, 27 Nov 2015 09:04:56 GMT
       Etag:
-      - '"25e4609fc3de37668f19925a16a7bb8c"'
+      - '"158b72b76170d91472611edb2aaabbd7"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2008,7 +2328,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2HxbWpprS0c8WMsGC0Ii2C
+      - content-api:4bBchoEZ9mImeGQKMQIMsO
       X-Powered-By:
       - Express
       Content-Length:
@@ -2037,61 +2357,61 @@ http_interactions:
                   },
                   "size": 6744
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/toy_image/198505151a9e451a0f3be3c51108e89c/toy_image.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/toy_image/ebbc3797b3895a4687cdac25abe478c1/toy_image.jpg"
               }
             }
           },
           "sys": {
             "id": "toy_image",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:46.429Z",
+            "createdAt": "2015-11-27T09:04:52.328Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:48.573Z",
+            "updatedAt": "2015-11-27T09:04:56.481Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:48.573Z",
+            "firstPublishedAt": "2015-11-27T09:04:56.481Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:48.573Z",
+            "publishedAt": "2015-11-27T09:04:56.481Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:48 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:58 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/kitchen_image
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/kitchen_image
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Kitchen and Home"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"kitchen_image.jpg","upload":"https://images.contentful.com/liicpxzmg1q0/6m5AJ9vMPKc8OUoQeoCS4o/ffc20f5a8f2a71cca4801bc9c51b966a/1418244847_Streamline-18-256.png?h=250&"}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2110,19 +2430,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:49 GMT
+      - Fri, 27 Nov 2015 09:04:57 GMT
       Etag:
-      - '"292a1e0d6407d1c442750686d471c7a6"'
+      - '"844fa9c2d2204bd413ca826a6206c1e9"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2130,7 +2450,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7mWx0MmShqaYC8W8scEU08
+      - content-api:2CA4nmgfqIG4uSSYQMGSim
       X-Powered-By:
       - Express
       Content-Length:
@@ -2160,42 +2480,42 @@ http_interactions:
             "id": "kitchen_image",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:49.657Z",
+            "createdAt": "2015-11-27T09:04:57.476Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:49.657Z",
+            "updatedAt": "2015-11-27T09:04:57.476Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:49 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:59 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/kitchen_image/files/en-US/process
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/kitchen_image/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2218,17 +2538,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:50 GMT
+      - Fri, 27 Nov 2015 09:04:58 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2236,7 +2556,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:tGtLi9pu36g6caGEqucww
+      - content-api:26U4ChSH9WGqeAAcuOk4yI
       X-Powered-By:
       - Express
       Connection:
@@ -2245,16 +2565,16 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:50 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:59 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/kitchen_image
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/kitchen_image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2275,19 +2595,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:51 GMT
+      - Fri, 27 Nov 2015 09:04:58 GMT
       Etag:
-      - '"295731fa608dd853d5f3fdddcd8afe2a"'
+      - '"dd2c769550b9d6f221d83ba3197963e6"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2295,7 +2615,113 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2CCpQ2fFneqs0UgEEyeQsw
+      - content-api:wxzCoXv9CKuumwiEAwsWI
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '986'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Kitchen and Home"
+            },
+            "description": {
+              "en-US": null
+            },
+            "file": {
+              "en-US": {
+                "contentType": "image/jpeg",
+                "fileName": "kitchen_image.jpg",
+                "upload": "https://images.contentful.com/liicpxzmg1q0/6m5AJ9vMPKc8OUoQeoCS4o/ffc20f5a8f2a71cca4801bc9c51b966a/1418244847_Streamline-18-256.png?h=250&"
+              }
+            }
+          },
+          "sys": {
+            "id": "kitchen_image",
+            "type": "Asset",
+            "createdAt": "2015-11-27T09:04:57.476Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "version": 1,
+            "updatedAt": "2015-11-27T09:04:57.521Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:00 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/kitchen_image
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:00 GMT
+      Etag:
+      - '"e157fed095192928096be79b027662c8"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:scMbYbSTVm0m8gIUSy4MK
       X-Powered-By:
       - Express
       Content-Length:
@@ -2324,50 +2750,50 @@ http_interactions:
                   },
                   "size": 4244
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/kitchen_image/53fe8dc76d2da7dc7db095e4a9dd57ef/kitchen_image.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/kitchen_image/d8a83fe032ecdf1e7421cb0526bea1e7/kitchen_image.jpg"
               }
             }
           },
           "sys": {
             "id": "kitchen_image",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:49.657Z",
+            "createdAt": "2015-11-27T09:04:57.476Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:50.957Z",
+            "updatedAt": "2015-11-27T09:04:58.838Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:50 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:01 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/kitchen_image/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/kitchen_image/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2390,19 +2816,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:51 GMT
+      - Fri, 27 Nov 2015 09:05:01 GMT
       Etag:
-      - '"d0738d6a35f733452eeb81a61b49f9e8"'
+      - '"b9db8189b15f6d77545cfa931d42800d"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2410,7 +2836,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1rkmYBF9tO6skgK46GYe8e
+      - content-api:4VWTshkwSkQGQIGIAGwG8a
       X-Powered-By:
       - Express
       Content-Length:
@@ -2439,61 +2865,61 @@ http_interactions:
                   },
                   "size": 4244
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/kitchen_image/53fe8dc76d2da7dc7db095e4a9dd57ef/kitchen_image.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/kitchen_image/d8a83fe032ecdf1e7421cb0526bea1e7/kitchen_image.jpg"
               }
             }
           },
           "sys": {
             "id": "kitchen_image",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:49.657Z",
+            "createdAt": "2015-11-27T09:04:57.476Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:51.804Z",
+            "updatedAt": "2015-11-27T09:05:01.040Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:51.804Z",
+            "firstPublishedAt": "2015-11-27T09:05:01.040Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:51.804Z",
+            "publishedAt": "2015-11-27T09:05:01.040Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:51 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:02 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/toy_car
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_car
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Playsam Toy Car"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"toy_car.jpg","upload":"https://images.contentful.com/liicpxzmg1q0/wtrHxeu3zEoEce2MokCSi/acef70d12fe019228c4238aa791bdd48/quwowooybuqbl6ntboz3.jpg?h=250&"}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2512,19 +2938,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:52 GMT
+      - Fri, 27 Nov 2015 09:05:02 GMT
       Etag:
-      - '"d887699994ee8dafde86f2aa10a9adf1"'
+      - '"f1c85e17ace19edb1c92c8f46a024700"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2532,7 +2958,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2hMNlIoq1asmIAMUaAwKKu
+      - content-api:2neQGiZ2ZCmeU0Eey6yGaY
       X-Powered-By:
       - Express
       Content-Length:
@@ -2562,42 +2988,42 @@ http_interactions:
             "id": "toy_car",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:52.889Z",
+            "createdAt": "2015-11-27T09:05:02.101Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:52.889Z",
+            "updatedAt": "2015-11-27T09:05:02.101Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:52 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:03 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/toy_car/files/en-US/process
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_car/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2620,17 +3046,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:53 GMT
+      - Fri, 27 Nov 2015 09:05:02 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2638,7 +3064,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2Umc0nfJ1eKoQIEmCw0Kyg
+      - content-api:2SDJZVsali2OaueoiW6UGW
       X-Powered-By:
       - Express
       Connection:
@@ -2647,16 +3073,16 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:53 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:04 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/toy_car
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_car
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2677,19 +3103,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:54 GMT
+      - Fri, 27 Nov 2015 09:05:03 GMT
       Etag:
-      - '"045c3ee3ddf31b469b0113060f4bd6cc"'
+      - '"d91497c2e5ab3c23c119c03601546947"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2697,7 +3123,113 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4rSc1zY2nuee2uOwckK2Qe
+      - content-api:CPm9YA5tks4aWmCMaIgmE
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '964'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Playsam Toy Car"
+            },
+            "description": {
+              "en-US": null
+            },
+            "file": {
+              "en-US": {
+                "contentType": "image/jpeg",
+                "fileName": "toy_car.jpg",
+                "upload": "https://images.contentful.com/liicpxzmg1q0/wtrHxeu3zEoEce2MokCSi/acef70d12fe019228c4238aa791bdd48/quwowooybuqbl6ntboz3.jpg?h=250&"
+              }
+            }
+          },
+          "sys": {
+            "id": "toy_car",
+            "type": "Asset",
+            "createdAt": "2015-11-27T09:05:02.101Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "version": 1,
+            "updatedAt": "2015-11-27T09:05:02.151Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:05 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_car
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:05 GMT
+      Etag:
+      - '"800dbb173ae6d5e561aabf362920d182"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:2RbHysJAP6kuUMSUq8mWoI
       X-Powered-By:
       - Express
       Content-Length:
@@ -2726,50 +3258,50 @@ http_interactions:
                   },
                   "size": 14416
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/toy_car/ab6852bfa30d20a6e0d190c85246731c/toy_car.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/toy_car/fef7b110d2a2d3af9c6f00f337cfb2cd/toy_car.jpg"
               }
             }
           },
           "sys": {
             "id": "toy_car",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:52.889Z",
+            "createdAt": "2015-11-27T09:05:02.101Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:54.209Z",
+            "updatedAt": "2015-11-27T09:05:03.642Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:54 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:06 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/toy_car/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/toy_car/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2792,19 +3324,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:55 GMT
+      - Fri, 27 Nov 2015 09:05:06 GMT
       Etag:
-      - '"b265e0c381b37cc5c102815051ea10b7"'
+      - '"f174b6ae3f6502eadb812e49253b71dd"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2812,7 +3344,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5rBC47Fvsk0YAYseyauwq8
+      - content-api:yS7va5xO6WSEYWgAGGWIo
       X-Powered-By:
       - Express
       Content-Length:
@@ -2841,61 +3373,61 @@ http_interactions:
                   },
                   "size": 14416
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/toy_car/ab6852bfa30d20a6e0d190c85246731c/toy_car.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/toy_car/fef7b110d2a2d3af9c6f00f337cfb2cd/toy_car.jpg"
               }
             }
           },
           "sys": {
             "id": "toy_car",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:52.889Z",
+            "createdAt": "2015-11-27T09:05:02.101Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:55.054Z",
+            "updatedAt": "2015-11-27T09:05:05.833Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:55.054Z",
+            "firstPublishedAt": "2015-11-27T09:05:05.833Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:55.054Z",
+            "publishedAt": "2015-11-27T09:05:05.833Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:55 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:07 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/whiskers
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/whiskers
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Normann Whisk Beaters"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"whiskers.jpg","upload":"https://images.contentful.com/liicpxzmg1q0/10TkaLheGeQG6qQGqWYqUI/d510dde5e575d40288cf75b42383aa53/ryugj83mqwa1asojwtwb.jpg?h=250&"}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2914,19 +3446,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:56 GMT
+      - Fri, 27 Nov 2015 09:05:06 GMT
       Etag:
-      - '"c52d916ab0679089ef5015e5c7f5b403"'
+      - '"324ef65dcb696e7ef88fd53a990e7a65"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2934,7 +3466,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3ZNAS910xOSy8EKCmUoQWg
+      - content-api:5ZRDOB2gKWUO2acsyEGoi0
       X-Powered-By:
       - Express
       Content-Length:
@@ -2964,42 +3496,42 @@ http_interactions:
             "id": "whiskers",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:56.200Z",
+            "createdAt": "2015-11-27T09:05:06.836Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "updatedAt": "2015-11-18T15:25:56.200Z",
+            "updatedAt": "2015-11-27T09:05:06.836Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:56 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:08 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/whiskers/files/en-US/process
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/whiskers/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3022,17 +3554,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:57 GMT
+      - Fri, 27 Nov 2015 09:05:07 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3040,7 +3572,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5FnDgviRQQO4UcSaCyYsQU
+      - content-api:GuOkDDkxs2g6YQAsK6Gwm
       X-Powered-By:
       - Express
       Connection:
@@ -3049,16 +3581,16 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:56 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:09 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/whiskers
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/whiskers
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3079,19 +3611,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:57 GMT
+      - Fri, 27 Nov 2015 09:05:08 GMT
       Etag:
-      - '"d31ed50e5d9e996bd774587c24bfb2a4"'
+      - '"bb225852f09612f90ac3bbaf0515bea5"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3099,7 +3631,113 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:WExfr30nYc0ioOI6wIOWC
+      - content-api:s9KAUtX3Hi6IQgS2YeA02
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '973'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Normann Whisk Beaters"
+            },
+            "description": {
+              "en-US": null
+            },
+            "file": {
+              "en-US": {
+                "contentType": "image/jpeg",
+                "fileName": "whiskers.jpg",
+                "upload": "https://images.contentful.com/liicpxzmg1q0/10TkaLheGeQG6qQGqWYqUI/d510dde5e575d40288cf75b42383aa53/ryugj83mqwa1asojwtwb.jpg?h=250&"
+              }
+            }
+          },
+          "sys": {
+            "id": "whiskers",
+            "type": "Asset",
+            "createdAt": "2015-11-27T09:05:06.836Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "version": 1,
+            "updatedAt": "2015-11-27T09:05:06.881Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:10 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/whiskers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:10 GMT
+      Etag:
+      - '"76ce6a6820ee218fe3901c19308206f0"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:2mykNEluIouWaWkI8q4MKs
       X-Powered-By:
       - Express
       Content-Length:
@@ -3128,50 +3766,50 @@ http_interactions:
                   },
                   "size": 10554
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/whiskers/2b5a6dfb54b0bfb6b4f080d6d57d10ce/whiskers.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/whiskers/18597f7be80a4340df86a18c691c57a3/whiskers.jpg"
               }
             }
           },
           "sys": {
             "id": "whiskers",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:56.200Z",
+            "createdAt": "2015-11-27T09:05:06.836Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:57.518Z",
+            "updatedAt": "2015-11-27T09:05:08.526Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:57 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:11 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/assets/whiskers/published
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/assets/whiskers/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3194,19 +3832,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:58 GMT
+      - Fri, 27 Nov 2015 09:05:10 GMT
       Etag:
-      - '"ee167314e350f7bc7a8dd11643d0b1d3"'
+      - '"dbe0cf8b8c2617a41e380f6a6ba30522"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3214,7 +3852,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4eXkeOlGtygYs4OUkAu0Wq
+      - content-api:5oxieNGeuAaqMYSwe04wMc
       X-Powered-By:
       - Express
       Content-Length:
@@ -3243,61 +3881,61 @@ http_interactions:
                   },
                   "size": 10554
                 },
-                "url": "//images.contentful.com/x4aalb1l82h7/whiskers/2b5a6dfb54b0bfb6b4f080d6d57d10ce/whiskers.jpg"
+                "url": "//images.contentful.com/rlql1v35lr9w/whiskers/18597f7be80a4340df86a18c691c57a3/whiskers.jpg"
               }
             }
           },
           "sys": {
             "id": "whiskers",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:56.200Z",
+            "createdAt": "2015-11-27T09:05:06.836Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:58.398Z",
+            "updatedAt": "2015-11-27T09:05:10.702Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:58.398Z",
+            "firstPublishedAt": "2015-11-27T09:05:10.702Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:58.398Z",
+            "publishedAt": "2015-11-27T09:05:10.702Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:58 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:12 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/brand
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/brand
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3318,19 +3956,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:59 GMT
+      - Fri, 27 Nov 2015 09:05:11 GMT
       Etag:
-      - '"b821a74789ed9e3359a0f01074936e56"'
+      - '"1fedd8ee4cbc82be2d7ca9fd5eb5bbe5"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3338,7 +3976,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3dxMdjd3XqMyg8WKcUceUU
+      - content-api:74UOKNQT9SCyqUMOueeueg
       X-Powered-By:
       - Express
       Content-Length:
@@ -3379,54 +4017,54 @@ http_interactions:
           "sys": {
             "id": "brand",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:32.401Z",
+            "createdAt": "2015-11-27T09:04:30.361Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:33.177Z",
+            "firstPublishedAt": "2015-11-27T09:04:33.908Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:33.177Z",
+            "publishedAt": "2015-11-27T09:04:33.908Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:33.188Z",
+            "updatedAt": "2015-11-27T09:04:33.963Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:59 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:13 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/playsam
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Playsam, Inc"},"website":{"en-US":"http://www.playsam.com"},"logo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"playsam_image"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3447,19 +4085,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:00 GMT
+      - Fri, 27 Nov 2015 09:05:12 GMT
       Etag:
-      - '"0334ba403984b23fc927f690b21874a6"'
+      - '"6f953ec3822d5c7b3a3d684d5a76ab10"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3467,51 +4105,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5cRkU5chMQ8OYq4uuSI0w0
+      - content-api:647sBW30HeYEA46iKGIQuU
       X-Powered-By:
       - Express
       Content-Length:
-      - '1002'
+      - '723'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Playsam, Inc"
-            },
-            "website": {
-              "en-US": "http://www.playsam.com"
-            },
-            "logo": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "playsam_image"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "playsam",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:26:00.253Z",
+            "createdAt": "2015-11-27T09:05:12.320Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -3521,27 +4143,27 @@ http_interactions:
                 "id": "brand"
               }
             },
-            "updatedAt": "2015-11-18T15:26:00.254Z",
+            "updatedAt": "2015-11-27T09:05:12.320Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:00 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:14 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/playsam
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Playsam, Inc"},"website":{"en-US":"http://www.playsam.com"},"logo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"playsam_image"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3562,19 +4184,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:01 GMT
+      - Fri, 27 Nov 2015 09:05:13 GMT
       Etag:
-      - '"1e1be23b7193f4a8009bee2599cd06d1"'
+      - '"c33bf67236e7bc9ca469944611eaaf68"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3582,50 +4204,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:kQFRREUdNIuyqqGAA48oc
+      - content-api:1qRi675eO4YsUS486ocEAW
       X-Powered-By:
       - Express
       Content-Length:
-      - '1002'
+      - '723'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Playsam, Inc"
-            },
-            "website": {
-              "en-US": "http://www.playsam.com"
-            },
-            "logo": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "playsam_image"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "playsam",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:00.253Z",
+            "createdAt": "2015-11-27T09:05:12.320Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -3636,27 +4242,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:26:01.285Z",
+            "updatedAt": "2015-11-27T09:05:13.300Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:01 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:14 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/normann
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/normann
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Normann Copenhagen, Inc"},"website":{"en-US":"http://www.normann-copenhagen.com/"},"logo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"normann_image"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3677,19 +4283,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:02 GMT
+      - Fri, 27 Nov 2015 09:05:14 GMT
       Etag:
-      - '"e3fe97b8d2be20529b92b227f4c22141"'
+      - '"9775ef344c3ae2ca9771db6138c1b169"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3697,51 +4303,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5zx0tlAd5moKye4IS6yoCC
+      - content-api:FrG3eh5qqAWGSeuQuS2m
       X-Powered-By:
       - Express
       Content-Length:
-      - '1025'
+      - '723'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Normann Copenhagen, Inc"
-            },
-            "website": {
-              "en-US": "http://www.normann-copenhagen.com/"
-            },
-            "logo": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "normann_image"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "normann",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:26:02.316Z",
+            "createdAt": "2015-11-27T09:05:14.229Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -3751,27 +4341,27 @@ http_interactions:
                 "id": "brand"
               }
             },
-            "updatedAt": "2015-11-18T15:26:02.316Z",
+            "updatedAt": "2015-11-27T09:05:14.229Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:02 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:15 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/normann
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/normann
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Normann Copenhagen, Inc"},"website":{"en-US":"http://www.normann-copenhagen.com/"},"logo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"normann_image"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3792,19 +4382,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:03 GMT
+      - Fri, 27 Nov 2015 09:05:15 GMT
       Etag:
-      - '"7f2828c1dfaa20714d7d98640444282e"'
+      - '"1015bd25594ef9409cd529884c2f3043"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3812,50 +4402,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:HUaJ2ffoUoQsww4Eic4WE
+      - content-api:56xzd34Fnq08SC28AMWqOQ
       X-Powered-By:
       - Express
       Content-Length:
-      - '1025'
+      - '723'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Normann Copenhagen, Inc"
-            },
-            "website": {
-              "en-US": "http://www.normann-copenhagen.com/"
-            },
-            "logo": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "normann_image"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "normann",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:02.316Z",
+            "createdAt": "2015-11-27T09:05:14.229Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -3866,27 +4440,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:26:03.319Z",
+            "updatedAt": "2015-11-27T09:05:15.192Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:03 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:16 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/category
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/category
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3907,19 +4481,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:04 GMT
+      - Fri, 27 Nov 2015 09:05:15 GMT
       Etag:
-      - '"9f99a70b21b1f7a251de8576c55a2b67"'
+      - '"7a662eaf4ed14839d521411bd2a44032"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3927,7 +4501,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2bss1tA6WUmcKQo2aAWmC6
+      - content-api:3AZzvYA7raqCYMQQ8ma4o4
       X-Powered-By:
       - Express
       Content-Length:
@@ -3968,55 +4542,54 @@ http_interactions:
           "sys": {
             "id": "category",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:34.733Z",
+            "createdAt": "2015-11-27T09:04:38.497Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:35.508Z",
+            "firstPublishedAt": "2015-11-27T09:04:39.235Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:35.508Z",
+            "publishedAt": "2015-11-27T09:04:39.235Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:35.518Z",
+            "updatedAt": "2015-11-27T09:04:39.285Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:03 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:17 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/toys
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/toys
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"Toys"},"description":{"en-US":"Toys for
-        children"},"icon":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"toy_image"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -4037,19 +4610,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:04 GMT
+      - Fri, 27 Nov 2015 09:05:16 GMT
       Etag:
-      - '"a9a2edde60f4c87dd8145781e17eac71"'
+      - '"246f7b20513fbc310062fb6de8696b54"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -4057,51 +4630,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7GgINhWQViIICuoGoeUC4K
+      - content-api:1nQoBONxikmkCOWeS6e4Uu
       X-Powered-By:
       - Express
       Content-Length:
-      - '990'
+      - '723'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "Toys"
-            },
-            "description": {
-              "en-US": "Toys for children"
-            },
-            "icon": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "toy_image"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "toys",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:26:04.840Z",
+            "createdAt": "2015-11-27T09:05:16.657Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -4111,28 +4668,27 @@ http_interactions:
                 "id": "category"
               }
             },
-            "updatedAt": "2015-11-18T15:26:04.840Z",
+            "updatedAt": "2015-11-27T09:05:16.657Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:04 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:18 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/toys
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/toys
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"Toys"},"description":{"en-US":"Toys for
-        children"},"icon":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"toy_image"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -4153,19 +4709,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:05 GMT
+      - Fri, 27 Nov 2015 09:05:17 GMT
       Etag:
-      - '"e841f5387747bb7ffc3d1294d5d04649"'
+      - '"6242e0d0326794d1b162a54a3b855659"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -4173,50 +4729,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:rbfVRnbSASG2Y0qQykggY
+      - content-api:3kKAbySHUACeaSu6oq6QOc
       X-Powered-By:
       - Express
       Content-Length:
-      - '990'
+      - '723'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "Toys"
-            },
-            "description": {
-              "en-US": "Toys for children"
-            },
-            "icon": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "toy_image"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "toys",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:04.840Z",
+            "createdAt": "2015-11-27T09:05:16.657Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -4227,28 +4767,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:26:05.829Z",
+            "updatedAt": "2015-11-27T09:05:17.632Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:05 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:19 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/kitchen
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/kitchen
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"House and Kitchen"},"description":{"en-US":"House
-        and Kitchen accessories"},"icon":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"kitchen_image"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -4269,19 +4808,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:06 GMT
+      - Fri, 27 Nov 2015 09:05:18 GMT
       Etag:
-      - '"6283f79586fa9278d34a2ed4a1e70335"'
+      - '"aebd8a1382a9a820826b35efdfa60723"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -4289,51 +4828,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:wRdShJLEXuQweqoSAysiG
+      - content-api:6w5QB9I4TYCsaccGCWwcIe
       X-Powered-By:
       - Express
       Content-Length:
-      - '1022'
+      - '726'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "House and Kitchen"
-            },
-            "description": {
-              "en-US": "House and Kitchen accessories"
-            },
-            "icon": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "kitchen_image"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "kitchen",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:26:06.844Z",
+            "createdAt": "2015-11-27T09:05:18.557Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -4343,28 +4866,27 @@ http_interactions:
                 "id": "category"
               }
             },
-            "updatedAt": "2015-11-18T15:26:06.844Z",
+            "updatedAt": "2015-11-27T09:05:18.557Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:06 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:20 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/kitchen
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/kitchen
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"House and Kitchen"},"description":{"en-US":"House
-        and Kitchen accessories"},"icon":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"kitchen_image"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -4385,19 +4907,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:07 GMT
+      - Fri, 27 Nov 2015 09:05:19 GMT
       Etag:
-      - '"9af58e6b9d64f5e7b9ef8da7f2b928bc"'
+      - '"4a69aaff2d152b5ff9b25476c46ba70a"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -4405,50 +4927,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5nslJwX1ReqQCCegwgmWk8
+      - content-api:5ilQXQ4IXYO6CkGScSyu4S
       X-Powered-By:
       - Express
       Content-Length:
-      - '1022'
+      - '726'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "House and Kitchen"
-            },
-            "description": {
-              "en-US": "House and Kitchen accessories"
-            },
-            "icon": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "kitchen_image"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "kitchen",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:06.844Z",
+            "createdAt": "2015-11-27T09:05:18.557Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -4459,27 +4965,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:26:07.855Z",
+            "updatedAt": "2015-11-27T09:05:19.579Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:07 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:21 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/content_types/product
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/content_types/product
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -4500,19 +5006,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:08 GMT
+      - Fri, 27 Nov 2015 09:05:20 GMT
       Etag:
-      - '"6adb7281ddfa6a344559fcde6f538293"'
+      - '"c1c51a0b1b87ec333c09fce4e1fb3df7"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -4520,7 +5026,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:61GqDUivbacuug2MQMKUYC
+      - content-api:W2GUYMUDkaOuaEGwIM0o8
       X-Powered-By:
       - Express
       Content-Length:
@@ -4584,58 +5090,54 @@ http_interactions:
           "sys": {
             "id": "product",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:37.517Z",
+            "createdAt": "2015-11-27T09:04:41.101Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:38.245Z",
+            "firstPublishedAt": "2015-11-27T09:04:41.797Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:38.245Z",
+            "publishedAt": "2015-11-27T09:04:41.797Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:38.273Z",
+            "updatedAt": "2015-11-27T09:04:41.855Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:08 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:21 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/playsam_car
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam_car
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Playsam Streamliner Classic Car, Espresso"},"description":{"en-US":"A
-        classic Playsam design, the Streamliner Classic Car has been selected as Swedish
-        Design Classic by the Swedish National Museum for its inventive style and
-        sleek surface. It''s no wonder that this wooden car has also been a long-standing
-        favorite for children both big and small!"},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"toy_car"}}},"brand":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"playsam"}}},"category":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"toys"}}},"url":{"en-US":"http://www.amazon.com/dp/B001R6JUZ2/"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -4656,19 +5158,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:09 GMT
+      - Fri, 27 Nov 2015 09:05:21 GMT
       Etag:
-      - '"37e5092a472908067662d661534092bd"'
+      - '"764f55e898ac1f66f723c809920deeae"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -4676,72 +5178,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1EcF5XAFb682IeWw4AUKKK
+      - content-api:1wBNWbYNZimGkyQGeyAgIW
       X-Powered-By:
       - Express
       Content-Length:
-      - '1681'
+      - '729'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Playsam Streamliner Classic Car, Espresso"
-            },
-            "description": {
-              "en-US": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!"
-            },
-            "image": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "toy_car"
-                }
-              }
-            },
-            "brand": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "playsam"
-                }
-              }
-            },
-            "category": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "toys"
-                }
-              }
-            },
-            "url": {
-              "en-US": "http://www.amazon.com/dp/B001R6JUZ2/"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "playsam_car",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:26:09.393Z",
+            "createdAt": "2015-11-27T09:05:21.096Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -4751,31 +5216,27 @@ http_interactions:
                 "id": "product"
               }
             },
-            "updatedAt": "2015-11-18T15:26:09.393Z",
+            "updatedAt": "2015-11-27T09:05:21.096Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:09 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:22 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/playsam_car
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam_car
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Playsam Streamliner Classic Car, Espresso"},"description":{"en-US":"A
-        classic Playsam design, the Streamliner Classic Car has been selected as Swedish
-        Design Classic by the Swedish National Museum for its inventive style and
-        sleek surface. It''s no wonder that this wooden car has also been a long-standing
-        favorite for children both big and small!"},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"toy_car"}}},"brand":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"playsam"}}},"category":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"toys"}}},"url":{"en-US":"http://www.amazon.com/dp/B001R6JUZ2/"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -4796,19 +5257,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:10 GMT
+      - Fri, 27 Nov 2015 09:05:22 GMT
       Etag:
-      - '"41b0d8bb4708c87e27904f16e55eaf20"'
+      - '"7b4d9a8ed0a973360c61fe38d6905283"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -4816,71 +5277,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4KZmBcegXuQ6i8YSkg6qUM
+      - content-api:7nJdqpfN3aM2ic02qcKMWU
       X-Powered-By:
       - Express
       Content-Length:
-      - '1681'
+      - '729'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Playsam Streamliner Classic Car, Espresso"
-            },
-            "description": {
-              "en-US": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!"
-            },
-            "image": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "toy_car"
-                }
-              }
-            },
-            "brand": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "playsam"
-                }
-              }
-            },
-            "category": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "toys"
-                }
-              }
-            },
-            "url": {
-              "en-US": "http://www.amazon.com/dp/B001R6JUZ2/"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "playsam_car",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:09.393Z",
+            "createdAt": "2015-11-27T09:05:21.096Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -4891,29 +5315,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:26:10.412Z",
+            "updatedAt": "2015-11-27T09:05:21.996Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:10 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:23 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/whisk_beater
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/whisk_beater
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Whisk Beater"},"description":{"en-US":"A
-        creative little whisk that comes in 8 different colors. Handy and easy to
-        clean after use. A great gift idea."},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"whiskers"}}},"brand":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"normann"}}},"category":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"kitchen"}}},"url":{"en-US":"http://www.amazon.com/dp/B0081F2CCK/"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -4934,19 +5356,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:11 GMT
+      - Fri, 27 Nov 2015 09:05:22 GMT
       Etag:
-      - '"d2d9f344c40860d59a6867770d1d833a"'
+      - '"754ed752616d14574b33dbd756458046"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -4954,72 +5376,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7IZbVYPs64yQGYc8KksiKU
+      - content-api:tBxds4jBcsoYuS44SE6SS
       X-Powered-By:
       - Express
       Content-Length:
-      - '1489'
+      - '730'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Whisk Beater"
-            },
-            "description": {
-              "en-US": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea."
-            },
-            "image": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "whiskers"
-                }
-              }
-            },
-            "brand": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "normann"
-                }
-              }
-            },
-            "category": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "kitchen"
-                }
-              }
-            },
-            "url": {
-              "en-US": "http://www.amazon.com/dp/B0081F2CCK/"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "whisk_beater",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:26:11.417Z",
+            "createdAt": "2015-11-27T09:05:22.865Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -5029,29 +5414,27 @@ http_interactions:
                 "id": "product"
               }
             },
-            "updatedAt": "2015-11-18T15:26:11.417Z",
+            "updatedAt": "2015-11-27T09:05:22.865Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:11 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:24 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/whisk_beater
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/whisk_beater
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Whisk Beater"},"description":{"en-US":"A
-        creative little whisk that comes in 8 different colors. Handy and easy to
-        clean after use. A great gift idea."},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"whiskers"}}},"brand":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"normann"}}},"category":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"kitchen"}}},"url":{"en-US":"http://www.amazon.com/dp/B0081F2CCK/"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -5072,19 +5455,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:12 GMT
+      - Fri, 27 Nov 2015 09:05:23 GMT
       Etag:
-      - '"e0621e0fe71f4ebf139327bb435d38f5"'
+      - '"7a159ba8567af93ce5770505b7aa27ca"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -5092,71 +5475,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:lrIzHfzVN6K0KQWq4so8y
+      - content-api:4naS381RYswwwuiewKAACK
       X-Powered-By:
       - Express
       Content-Length:
-      - '1489'
+      - '730'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Whisk Beater"
-            },
-            "description": {
-              "en-US": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea."
-            },
-            "image": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "whiskers"
-                }
-              }
-            },
-            "brand": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "normann"
-                }
-              }
-            },
-            "category": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "kitchen"
-                }
-              }
-            },
-            "url": {
-              "en-US": "http://www.amazon.com/dp/B0081F2CCK/"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "whisk_beater",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:11.417Z",
+            "createdAt": "2015-11-27T09:05:22.865Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -5167,210 +5513,31 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:26:12.463Z",
+            "updatedAt": "2015-11-27T09:05:23.859Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:12 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:25 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries?content_type=brand
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      Connection:
-      - close
-      Host:
-      - api.contentful.com
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
-      Access-Control-Allow-Methods:
-      - DELETE,GET,HEAD,POST,PUT,OPTIONS
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Etag
-      Access-Control-Max-Age:
-      - '1728000'
-      Cf-Space-Id:
-      - x4aalb1l82h7
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      Date:
-      - Wed, 18 Nov 2015 15:26:13 GMT
-      Etag:
-      - '"d5db7aeb74e9573f9b8a74675926d558"'
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Content-Type-Options:
-      - nosniff
-      X-Contentful-Request-Id:
-      - content-api:4BDLJ1KTDGGuGCWCcAYsQA
-      X-Powered-By:
-      - Express
-      Content-Length:
-      - '2560'
-      Connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "sys": {
-            "type": "Array"
-          },
-          "total": 2,
-          "skip": 0,
-          "limit": 100,
-          "items": [
-            {
-              "fields": {
-                "name": {
-                  "en-US": "Playsam, Inc"
-                },
-                "website": {
-                  "en-US": "http://www.playsam.com"
-                },
-                "logo": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Asset",
-                      "id": "playsam_image"
-                    }
-                  }
-                }
-              },
-              "sys": {
-                "id": "playsam",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:26:00.253Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "x4aalb1l82h7"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "brand"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:26:01.342Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            },
-            {
-              "fields": {
-                "name": {
-                  "en-US": "Normann Copenhagen, Inc"
-                },
-                "website": {
-                  "en-US": "http://www.normann-copenhagen.com/"
-                },
-                "logo": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Asset",
-                      "id": "normann_image"
-                    }
-                  }
-                }
-              },
-              "sys": {
-                "id": "normann",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:26:02.316Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "x4aalb1l82h7"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "brand"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:26:03.383Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:13 GMT
-- request:
-    method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/playsam/published
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RubyContentfulManagementGem/0.7.2
-      Authorization:
-      - Bearer foobar
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -5387,19 +5554,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:14 GMT
+      - Fri, 27 Nov 2015 09:05:24 GMT
       Etag:
-      - '"b8d9742714f516e38637fc8ebed1a234"'
+      - '"305c1332baf9adadab2d9ec2a264c426"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -5407,7 +5574,2930 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4ko4OKCD6go0CeSmq0eeKO
+      - content-api:4TqFTYNtu0AoM2IEAEyQQC
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '723'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "playsam",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:12.320Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:05:13.343Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:26 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Playsam, Inc"},"website":{"en-US":"http://www.playsam.com"},"logo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"playsam_image"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:25 GMT
+      Etag:
+      - '"eb77b521550b35dcb68a18f76592aea7"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3xM0ZC2tdYkqeoU2AkWsaA
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1002'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Playsam, Inc"
+            },
+            "website": {
+              "en-US": "http://www.playsam.com"
+            },
+            "logo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "playsam_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "playsam",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:12.320Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:05:25.379Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:27 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Playsam, Inc"},"website":{"en-US":"http://www.playsam.com"},"logo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"playsam_image"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:26 GMT
+      Etag:
+      - '"c69c3a82ddba69b8df53c1fe3db3d508"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:7Ed7jJm3AIKuYK0UUoeouW
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1002'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Playsam, Inc"
+            },
+            "website": {
+              "en-US": "http://www.playsam.com"
+            },
+            "logo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "playsam_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "playsam",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:12.320Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:26.284Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:27 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:26 GMT
+      Etag:
+      - '"73692774657c75beb05e7a1d6e509a10"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:oN2epYB5Nmeyss4qskWcG
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1002'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Playsam, Inc"
+            },
+            "website": {
+              "en-US": "http://www.playsam.com"
+            },
+            "logo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "playsam_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "playsam",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:12.320Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:26.327Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:28 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/normann
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:27 GMT
+      Etag:
+      - '"dae9ee13f46a3e7d2897f5a1adbc6eb4"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1fRm3LXtPAiKMCC2AcEuAA
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '723'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "normann",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:14.229Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:05:15.238Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:29 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/normann
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Normann Copenhagen, Inc"},"website":{"en-US":"http://www.normann-copenhagen.com/"},"logo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"normann_image"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:28 GMT
+      Etag:
+      - '"a650a1e7ee3e43ba84505f8d1c711583"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:vK2xwLZg52aucICOqKyUU
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1025'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Normann Copenhagen, Inc"
+            },
+            "website": {
+              "en-US": "http://www.normann-copenhagen.com/"
+            },
+            "logo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "normann_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "normann",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:14.229Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:05:28.340Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:30 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/normann
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Normann Copenhagen, Inc"},"website":{"en-US":"http://www.normann-copenhagen.com/"},"logo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"normann_image"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:29 GMT
+      Etag:
+      - '"0d1fef8487ec3c5e516731ecb912ec7e"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5ly726k3FmAO6MGGM6ycGW
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1025'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Normann Copenhagen, Inc"
+            },
+            "website": {
+              "en-US": "http://www.normann-copenhagen.com/"
+            },
+            "logo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "normann_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "normann",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:14.229Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:29.253Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:30 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/normann
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:29 GMT
+      Etag:
+      - '"ebd19e27054412eeb8fb5285a19b019c"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:6WBnjt2oes8aaOKKCG6gAm
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1025'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Normann Copenhagen, Inc"
+            },
+            "website": {
+              "en-US": "http://www.normann-copenhagen.com/"
+            },
+            "logo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "normann_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "normann",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:14.229Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:29.307Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:31 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/toys
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:30 GMT
+      Etag:
+      - '"9dda8836d48131536967877ff710a017"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4KS5ruQw0gqOiemscqiWY8
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '723'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "toys",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:16.657Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:05:17.678Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:32 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/toys
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"Toys"},"description":{"en-US":"Toys for
+        children"},"icon":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"toy_image"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:31 GMT
+      Etag:
+      - '"0e5dd2c54b7fdb2e6fbfa3ede2eed357"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1K9duS1xugyUYQayMiq8EQ
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '990'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Toys"
+            },
+            "description": {
+              "en-US": "Toys for children"
+            },
+            "icon": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "toy_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "toys",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:16.657Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:05:31.436Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:33 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/toys
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"Toys"},"description":{"en-US":"Toys for
+        children"},"icon":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"toy_image"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:32 GMT
+      Etag:
+      - '"eb4f57ff8e1caeca815d7ff0aa52d1f7"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:UaK1QlRroqCwsMYOgQI0e
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '990'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Toys"
+            },
+            "description": {
+              "en-US": "Toys for children"
+            },
+            "icon": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "toy_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "toys",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:16.657Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:32.444Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:34 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/toys
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:33 GMT
+      Etag:
+      - '"2e648e7671d4c307d313f306bc62b453"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4VlocczChOou8Mqc2Y4sce
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '990'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Toys"
+            },
+            "description": {
+              "en-US": "Toys for children"
+            },
+            "icon": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "toy_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "toys",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:16.657Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:32.490Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:34 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/kitchen
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:33 GMT
+      Etag:
+      - '"cc04b6678e4fffdf448b66c47d9f639c"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:6aaEfyA5WMmE6gmu0Q4s8M
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '726'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "kitchen",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:18.557Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:05:19.621Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:35 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/kitchen
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"House and Kitchen"},"description":{"en-US":"House
+        and Kitchen accessories"},"icon":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"kitchen_image"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:34 GMT
+      Etag:
+      - '"82b85b804afdeea41e8d3c11d0ea417b"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3SzBNyNCvCSOCAOK26Wu4g
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1022'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "House and Kitchen"
+            },
+            "description": {
+              "en-US": "House and Kitchen accessories"
+            },
+            "icon": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "kitchen_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "kitchen",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:18.557Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:05:34.580Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:36 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/kitchen
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"House and Kitchen"},"description":{"en-US":"House
+        and Kitchen accessories"},"icon":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"kitchen_image"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:35 GMT
+      Etag:
+      - '"41b077c5c6d5cd83fe104e5cd1d8ba0d"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:6G0WQVFJBK2GasU64mMeEQ
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1022'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "House and Kitchen"
+            },
+            "description": {
+              "en-US": "House and Kitchen accessories"
+            },
+            "icon": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "kitchen_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "kitchen",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:18.557Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:35.497Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:37 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/kitchen
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:36 GMT
+      Etag:
+      - '"bb8e7a8459710aa17464fc2a44b6dba9"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:9nZ4xwe6SA4eUG4Qk40G0
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1022'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "House and Kitchen"
+            },
+            "description": {
+              "en-US": "House and Kitchen accessories"
+            },
+            "icon": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "kitchen_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "kitchen",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:18.557Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:35.547Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:37 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam_car
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:36 GMT
+      Etag:
+      - '"9627257de89891c79baca0994de5a315"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4wafYGgu3KWyWCaiSWGkG4
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '729'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "playsam_car",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:21.096Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:05:22.038Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:38 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam_car
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Playsam Streamliner Classic Car, Espresso"},"description":{"en-US":"A
+        classic Playsam design, the Streamliner Classic Car has been selected as Swedish
+        Design Classic by the Swedish National Museum for its inventive style and
+        sleek surface. It''s no wonder that this wooden car has also been a long-standing
+        favorite for children both big and small!"},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"toy_car"}}},"brand":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"playsam"}}},"category":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"toys"}}},"url":{"en-US":"http://www.amazon.com/dp/B001R6JUZ2/"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:37 GMT
+      Etag:
+      - '"4d11ee212ffba091f47b7e2074abddfe"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5tbOgbotEWwIOccE2MmqKO
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1681'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Playsam Streamliner Classic Car, Espresso"
+            },
+            "description": {
+              "en-US": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!"
+            },
+            "image": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "toy_car"
+                }
+              }
+            },
+            "brand": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "playsam"
+                }
+              }
+            },
+            "category": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "toys"
+                }
+              }
+            },
+            "url": {
+              "en-US": "http://www.amazon.com/dp/B001R6JUZ2/"
+            }
+          },
+          "sys": {
+            "id": "playsam_car",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:21.096Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:05:37.516Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:39 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam_car
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Playsam Streamliner Classic Car, Espresso"},"description":{"en-US":"A
+        classic Playsam design, the Streamliner Classic Car has been selected as Swedish
+        Design Classic by the Swedish National Museum for its inventive style and
+        sleek surface. It''s no wonder that this wooden car has also been a long-standing
+        favorite for children both big and small!"},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"toy_car"}}},"brand":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"playsam"}}},"category":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"toys"}}},"url":{"en-US":"http://www.amazon.com/dp/B001R6JUZ2/"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:38 GMT
+      Etag:
+      - '"1ff6ca5524cd9751b6ed03cfe340288b"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:PmFKdm3FYIseWOKqAAmk0
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1681'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Playsam Streamliner Classic Car, Espresso"
+            },
+            "description": {
+              "en-US": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!"
+            },
+            "image": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "toy_car"
+                }
+              }
+            },
+            "brand": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "playsam"
+                }
+              }
+            },
+            "category": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "toys"
+                }
+              }
+            },
+            "url": {
+              "en-US": "http://www.amazon.com/dp/B001R6JUZ2/"
+            }
+          },
+          "sys": {
+            "id": "playsam_car",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:21.096Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:38.401Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:40 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam_car
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:39 GMT
+      Etag:
+      - '"328c8c6a369e8ee39c03d446f96bfaf0"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:58anvMiqvSCgUy0CusKmy0
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1681'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Playsam Streamliner Classic Car, Espresso"
+            },
+            "description": {
+              "en-US": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!"
+            },
+            "image": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "toy_car"
+                }
+              }
+            },
+            "brand": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "playsam"
+                }
+              }
+            },
+            "category": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "toys"
+                }
+              }
+            },
+            "url": {
+              "en-US": "http://www.amazon.com/dp/B001R6JUZ2/"
+            }
+          },
+          "sys": {
+            "id": "playsam_car",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:21.096Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:38.455Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:40 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/whisk_beater
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:39 GMT
+      Etag:
+      - '"7b4c67277773cba0126b1ea2ceaa7927"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3O4k3kGFqwUsoAQUsOSkKo
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '730'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "whisk_beater",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:22.865Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:05:23.905Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:41 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/whisk_beater
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Whisk Beater"},"description":{"en-US":"A
+        creative little whisk that comes in 8 different colors. Handy and easy to
+        clean after use. A great gift idea."},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"whiskers"}}},"brand":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"normann"}}},"category":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"kitchen"}}},"url":{"en-US":"http://www.amazon.com/dp/B0081F2CCK/"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:40 GMT
+      Etag:
+      - '"0381451d2e298d75869c44482a9829b0"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3YxqyjQRe8oKIW02YuUUwg
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1489'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Whisk Beater"
+            },
+            "description": {
+              "en-US": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea."
+            },
+            "image": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "whiskers"
+                }
+              }
+            },
+            "brand": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "normann"
+                }
+              }
+            },
+            "category": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "kitchen"
+                }
+              }
+            },
+            "url": {
+              "en-US": "http://www.amazon.com/dp/B0081F2CCK/"
+            }
+          },
+          "sys": {
+            "id": "whisk_beater",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:22.865Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:05:40.539Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:42 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/whisk_beater
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Whisk Beater"},"description":{"en-US":"A
+        creative little whisk that comes in 8 different colors. Handy and easy to
+        clean after use. A great gift idea."},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"whiskers"}}},"brand":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"normann"}}},"category":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"kitchen"}}},"url":{"en-US":"http://www.amazon.com/dp/B0081F2CCK/"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:41 GMT
+      Etag:
+      - '"19d1770251eefd24185a548e217335bf"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4roy4SBMI0UScAGUWUAyyI
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1489'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Whisk Beater"
+            },
+            "description": {
+              "en-US": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea."
+            },
+            "image": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "whiskers"
+                }
+              }
+            },
+            "brand": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "normann"
+                }
+              }
+            },
+            "category": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "kitchen"
+                }
+              }
+            },
+            "url": {
+              "en-US": "http://www.amazon.com/dp/B0081F2CCK/"
+            }
+          },
+          "sys": {
+            "id": "whisk_beater",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:22.865Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:41.441Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:43 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/whisk_beater
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:42 GMT
+      Etag:
+      - '"3633f777f9c97bb1210a87a1ff69d449"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1wYC3jmjKsqI64e6M42E4k
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1489'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Whisk Beater"
+            },
+            "description": {
+              "en-US": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea."
+            },
+            "image": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "whiskers"
+                }
+              }
+            },
+            "brand": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "normann"
+                }
+              }
+            },
+            "category": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "kitchen"
+                }
+              }
+            },
+            "url": {
+              "en-US": "http://www.amazon.com/dp/B0081F2CCK/"
+            }
+          },
+          "sys": {
+            "id": "whisk_beater",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:22.865Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:41.495Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:43 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:42 GMT
+      Etag:
+      - '"73692774657c75beb05e7a1d6e509a10"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:xUbt7hCslUyeU0oQAqUWi
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1002'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Playsam, Inc"
+            },
+            "website": {
+              "en-US": "http://www.playsam.com"
+            },
+            "logo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "playsam_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "playsam",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:12.320Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:26.327Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:44 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:43 GMT
+      Etag:
+      - '"af3bf5dfc2828afec92205bce6b22d5a"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1p4nfdPGAUyEEOE0Oug8E8
       X-Powered-By:
       - Express
       Content-Length:
@@ -5438,19 +8528,19 @@ http_interactions:
           "sys": {
             "id": "playsam",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:00.253Z",
+            "createdAt": "2015-11-27T09:05:12.320Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -5460,45 +8550,43 @@ http_interactions:
                 "id": "brand"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:26:13.901Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:05:43.275Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:26:13.901Z",
+            "firstPublishedAt": "2015-11-27T09:05:43.275Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:26:13.901Z",
+            "publishedAt": "2015-11-27T09:05:43.275Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:13 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:45 GMT
 - request:
-    method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/normann/published
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/normann
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -5515,19 +8603,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:14 GMT
+      - Fri, 27 Nov 2015 09:05:44 GMT
       Etag:
-      - '"24b119ac6d5453cee53a69f2cb9416bc"'
+      - '"ebd19e27054412eeb8fb5285a19b019c"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -5535,7 +8623,124 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6HjXS0ARdSoioUWccIY6gG
+      - content-api:5lwiS0ghNY6wKOmcKoIoc2
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1025'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Normann Copenhagen, Inc"
+            },
+            "website": {
+              "en-US": "http://www.normann-copenhagen.com/"
+            },
+            "logo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "normann_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "normann",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:14.229Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "brand"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:29.307Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:45 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/normann/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:45 GMT
+      Etag:
+      - '"bc91466c0459548bf3d229a2e7f32c37"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4EmKS4ino4UIYI2OOqQOIs
       X-Powered-By:
       - Express
       Content-Length:
@@ -5566,19 +8771,19 @@ http_interactions:
           "sys": {
             "id": "normann",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:02.316Z",
+            "createdAt": "2015-11-27T09:05:14.229Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -5588,222 +8793,43 @@ http_interactions:
                 "id": "brand"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:26:14.785Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:05:44.709Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:26:14.785Z",
+            "firstPublishedAt": "2015-11-27T09:05:44.709Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:26:14.785Z",
+            "publishedAt": "2015-11-27T09:05:44.709Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:14 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:46 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries?content_type=category
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/toys
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      Connection:
-      - close
-      Host:
-      - api.contentful.com
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
-      Access-Control-Allow-Methods:
-      - DELETE,GET,HEAD,POST,PUT,OPTIONS
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Etag
-      Access-Control-Max-Age:
-      - '1728000'
-      Cf-Space-Id:
-      - x4aalb1l82h7
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      Date:
-      - Wed, 18 Nov 2015 15:26:15 GMT
-      Etag:
-      - '"5833bd41a823a018299d38b99faf2136"'
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Content-Type-Options:
-      - nosniff
-      X-Contentful-Request-Id:
-      - content-api:2ZC1Mkq4mkiAU6WeUmwis8
-      X-Powered-By:
-      - Express
-      Content-Length:
-      - '2545'
-      Connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "sys": {
-            "type": "Array"
-          },
-          "total": 2,
-          "skip": 0,
-          "limit": 100,
-          "items": [
-            {
-              "fields": {
-                "title": {
-                  "en-US": "Toys"
-                },
-                "description": {
-                  "en-US": "Toys for children"
-                },
-                "icon": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Asset",
-                      "id": "toy_image"
-                    }
-                  }
-                }
-              },
-              "sys": {
-                "id": "toys",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:26:04.840Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "x4aalb1l82h7"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "category"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:26:05.874Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            },
-            {
-              "fields": {
-                "title": {
-                  "en-US": "House and Kitchen"
-                },
-                "description": {
-                  "en-US": "House and Kitchen accessories"
-                },
-                "icon": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Asset",
-                      "id": "kitchen_image"
-                    }
-                  }
-                }
-              },
-              "sys": {
-                "id": "kitchen",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:26:06.844Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "x4aalb1l82h7"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "category"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:26:07.914Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:15 GMT
-- request:
-    method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/toys/published
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RubyContentfulManagementGem/0.7.2
-      Authorization:
-      - Bearer foobar
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -5820,19 +8846,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:16 GMT
+      - Fri, 27 Nov 2015 09:05:45 GMT
       Etag:
-      - '"289d345d8de075ca22a7b89c189051a7"'
+      - '"2e648e7671d4c307d313f306bc62b453"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -5840,7 +8866,124 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3n8T8KCklieYoQw4suUsA4
+      - content-api:1bMrENrEjqo6imgs8Y4oKy
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '990'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "Toys"
+            },
+            "description": {
+              "en-US": "Toys for children"
+            },
+            "icon": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "toy_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "toys",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:16.657Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:32.490Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:47 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/toys/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:46 GMT
+      Etag:
+      - '"2275cb9ea50b14f32783a8505defe1b0"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1fYnzeeawsEQwQWS0u2iaq
       X-Powered-By:
       - Express
       Content-Length:
@@ -5871,19 +9014,19 @@ http_interactions:
           "sys": {
             "id": "toys",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:04.840Z",
+            "createdAt": "2015-11-27T09:05:16.657Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -5893,45 +9036,43 @@ http_interactions:
                 "id": "category"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:26:16.328Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:05:46.473Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:26:16.328Z",
+            "firstPublishedAt": "2015-11-27T09:05:46.473Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:26:16.328Z",
+            "publishedAt": "2015-11-27T09:05:46.473Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:16 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:48 GMT
 - request:
-    method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/kitchen/published
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/kitchen
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -5948,19 +9089,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:17 GMT
+      - Fri, 27 Nov 2015 09:05:47 GMT
       Etag:
-      - '"c1f8d63030f62afcaf7adaa9c800e3fd"'
+      - '"bb8e7a8459710aa17464fc2a44b6dba9"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -5968,7 +9109,124 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5twCbezX0Ws4w0QiMCs4oe
+      - content-api:202E5TNYBOY8C6EQIGWCSU
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1022'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "House and Kitchen"
+            },
+            "description": {
+              "en-US": "House and Kitchen accessories"
+            },
+            "icon": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "kitchen_image"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "kitchen",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:18.557Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:35.547Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:48 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/kitchen/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:48 GMT
+      Etag:
+      - '"7dd2aa689dd9f226720633902d57a01e"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4VPtNxbRviWIcUiCUkCMek
       X-Powered-By:
       - Express
       Content-Length:
@@ -5999,19 +9257,19 @@ http_interactions:
           "sys": {
             "id": "kitchen",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:06.844Z",
+            "createdAt": "2015-11-27T09:05:18.557Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -6021,264 +9279,43 @@ http_interactions:
                 "id": "category"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:26:17.374Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:05:47.944Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:26:17.374Z",
+            "firstPublishedAt": "2015-11-27T09:05:47.944Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:26:17.374Z",
+            "publishedAt": "2015-11-27T09:05:47.944Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:17 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:49 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries?content_type=product
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam_car
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      Connection:
-      - close
-      Host:
-      - api.contentful.com
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
-      Access-Control-Allow-Methods:
-      - DELETE,GET,HEAD,POST,PUT,OPTIONS
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Etag
-      Access-Control-Max-Age:
-      - '1728000'
-      Cf-Space-Id:
-      - x4aalb1l82h7
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      Date:
-      - Wed, 18 Nov 2015 15:26:18 GMT
-      Etag:
-      - '"9cb926ea583f9eacce3f64fbd9305b39"'
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Content-Type-Options:
-      - nosniff
-      X-Contentful-Request-Id:
-      - content-api:6Kyp7YAGS4cOsm0ksawuMI
-      X-Powered-By:
-      - Express
-      Content-Length:
-      - '3871'
-      Connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "sys": {
-            "type": "Array"
-          },
-          "total": 2,
-          "skip": 0,
-          "limit": 100,
-          "items": [
-            {
-              "fields": {
-                "name": {
-                  "en-US": "Playsam Streamliner Classic Car, Espresso"
-                },
-                "description": {
-                  "en-US": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!"
-                },
-                "image": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Asset",
-                      "id": "toy_car"
-                    }
-                  }
-                },
-                "brand": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Entry",
-                      "id": "playsam"
-                    }
-                  }
-                },
-                "category": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Entry",
-                      "id": "toys"
-                    }
-                  }
-                },
-                "url": {
-                  "en-US": "http://www.amazon.com/dp/B001R6JUZ2/"
-                }
-              },
-              "sys": {
-                "id": "playsam_car",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:26:09.393Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "x4aalb1l82h7"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "product"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:26:10.458Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            },
-            {
-              "fields": {
-                "name": {
-                  "en-US": "Whisk Beater"
-                },
-                "description": {
-                  "en-US": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea."
-                },
-                "image": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Asset",
-                      "id": "whiskers"
-                    }
-                  }
-                },
-                "brand": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Entry",
-                      "id": "normann"
-                    }
-                  }
-                },
-                "category": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Entry",
-                      "id": "kitchen"
-                    }
-                  }
-                },
-                "url": {
-                  "en-US": "http://www.amazon.com/dp/B0081F2CCK/"
-                }
-              },
-              "sys": {
-                "id": "whisk_beater",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:26:11.417Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "x4aalb1l82h7"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "product"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:26:12.510Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:18 GMT
-- request:
-    method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/playsam_car/published
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RubyContentfulManagementGem/0.7.2
-      Authorization:
-      - Bearer foobar
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -6295,19 +9332,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:19 GMT
+      - Fri, 27 Nov 2015 09:05:48 GMT
       Etag:
-      - '"c3a64a899de0e44a0c8ead20df75fbab"'
+      - '"328c8c6a369e8ee39c03d446f96bfaf0"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -6315,7 +9352,145 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:l3gszLRpNmOcMKM8oWEUY
+      - content-api:20RUByfLmYAQ6eIYkSuuuQ
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1681'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Playsam Streamliner Classic Car, Espresso"
+            },
+            "description": {
+              "en-US": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!"
+            },
+            "image": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "toy_car"
+                }
+              }
+            },
+            "brand": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "playsam"
+                }
+              }
+            },
+            "category": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "toys"
+                }
+              }
+            },
+            "url": {
+              "en-US": "http://www.amazon.com/dp/B001R6JUZ2/"
+            }
+          },
+          "sys": {
+            "id": "playsam_car",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:21.096Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:38.455Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:50 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/playsam_car/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:49 GMT
+      Etag:
+      - '"a3140df4ce6e0624795bc2cc2647a70f"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:FYCOLTBxOSCOCU2y2smws
       X-Powered-By:
       - Express
       Content-Length:
@@ -6367,19 +9542,19 @@ http_interactions:
           "sys": {
             "id": "playsam_car",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:09.393Z",
+            "createdAt": "2015-11-27T09:05:21.096Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -6389,45 +9564,43 @@ http_interactions:
                 "id": "product"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:26:18.988Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:05:49.330Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:26:18.988Z",
+            "firstPublishedAt": "2015-11-27T09:05:49.330Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:26:18.988Z",
+            "publishedAt": "2015-11-27T09:05:49.330Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:19 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:51 GMT
 - request:
-    method: put
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/entries/whisk_beater/published
+    method: get
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/whisk_beater
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -6444,19 +9617,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - x4aalb1l82h7
+      - rlql1v35lr9w
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:20 GMT
+      - Fri, 27 Nov 2015 09:05:50 GMT
       Etag:
-      - '"945e5bafa778682a57a76d96c03d871f"'
+      - '"3633f777f9c97bb1210a87a1ff69d449"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -6464,7 +9637,145 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6rF0ANmREWYyq8C6c2I2cy
+      - content-api:4MzKr5AlR60agcyAYiKsmc
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1489'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Whisk Beater"
+            },
+            "description": {
+              "en-US": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea."
+            },
+            "image": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "whiskers"
+                }
+              }
+            },
+            "brand": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "normann"
+                }
+              }
+            },
+            "category": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "kitchen"
+                }
+              }
+            },
+            "url": {
+              "en-US": "http://www.amazon.com/dp/B0081F2CCK/"
+            }
+          },
+          "sys": {
+            "id": "whisk_beater",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:05:22.865Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rlql1v35lr9w"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "product"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:05:41.495Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:05:51 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/entries/whisk_beater/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - rlql1v35lr9w
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:05:50 GMT
+      Etag:
+      - '"da9e53dee886c8c1447ad7ff9f943699"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:60obbgj9YIaKQYiykAcsam
       X-Powered-By:
       - Express
       Content-Length:
@@ -6516,19 +9827,19 @@ http_interactions:
           "sys": {
             "id": "whisk_beater",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:26:11.417Z",
+            "createdAt": "2015-11-27T09:05:22.865Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "x4aalb1l82h7"
+                "id": "rlql1v35lr9w"
               }
             },
             "contentType": {
@@ -6538,40 +9849,40 @@ http_interactions:
                 "id": "product"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:26:19.902Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:05:50.778Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:26:19.902Z",
+            "firstPublishedAt": "2015-11-27T09:05:50.778Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:26:19.902Z",
+            "publishedAt": "2015-11-27T09:05:50.778Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:20 GMT
+  recorded_at: Fri, 27 Nov 2015 09:05:52 GMT
 - request:
     method: post
-    uri: https://api.contentful.com/spaces/x4aalb1l82h7/api_keys
+    uri: https://api.contentful.com/spaces/rlql1v35lr9w/api_keys
     body:
       encoding: UTF-8
       string: '{"name":"Bootstrap Token","description":"Created with ''contentful_bootstrap.rb
         v2.0.2''"}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -6592,7 +9903,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -6602,11 +9913,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:26:21 GMT
+      - Fri, 27 Nov 2015 09:05:51 GMT
       Etag:
-      - '"447d440f3aed365baf14ff598b6c1872"'
+      - '"9a796d847e0112d7326f9972b2310ee3"'
       Location:
-      - https://api.contentful.com/spaces/x4aalb1l82h7/api_keys/51kjmtnhYPkqvJSYGirxx7
+      - https://api.contentful.com/spaces/rlql1v35lr9w/api_keys/7Egj29uJ3PUhs5AfiEbbnH
       Server:
       - nginx
       Status:
@@ -6616,7 +9927,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - 9e1-615651782
+      - 9e1-621571048
       Content-Length:
       - '954'
       Connection:
@@ -6627,35 +9938,35 @@ http_interactions:
         {
           "sys":{
             "type":"ApiKey",
-            "id":"51kjmtnhYPkqvJSYGirxx7",
+            "id":"7Egj29uJ3PUhs5AfiEbbnH",
             "version":0,
             "space":{
               "sys":{
                 "type":"Link",
                 "linkType":"Space",
-                "id":"x4aalb1l82h7"
+                "id":"rlql1v35lr9w"
               }
             },
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-18T15:26:21Z",
+            "createdAt":"2015-11-27T09:05:51Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-18T15:26:21Z"
+            "updatedAt":"2015-11-27T09:05:51Z"
           },
           "name":"Bootstrap Token",
           "description":"Created with 'contentful_bootstrap.rb v2.0.2'",
-          "accessToken":"f829d543f618079a219739b7c61a93e4f63655d2f0b55176a96bae7bc42458fc",
+          "accessToken":"81f867c055c3b67b061b7b57d1fcbc234d88f652d35acbe0c73d8d144bbaa39e",
           "policies":[
             {
               "effect":"allow",
@@ -6666,11 +9977,11 @@ http_interactions:
             "sys":{
               "type":"Link",
               "linkType":"PreviewApiKey",
-              "id":"51loyF4VrAwtoyrYktxMkN"
+              "id":"7EhlOEZ8lEuc00lD2Evg3f"
             }
           }
         }
 
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:26:21 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Fri, 27 Nov 2015 09:05:53 GMT
+recorded_with: VCR 3.0.0

--- a/spec/fixtures/vcr_fixtures/create_space_with_gallery_template.yml
+++ b/spec/fixtures/vcr_fixtures/create_space_with_gallery_template.yml
@@ -8,11 +8,13 @@ http_interactions:
       string: '{"name":"gallery_space","defaultLocale":"en-US"}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
+      X-Contentful-Organization:
+      - 1PLOOEmTI2S1NYald2TemO
       Connection:
       - close
       Host:
@@ -29,7 +31,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -39,11 +41,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:24:59 GMT
+      - Fri, 27 Nov 2015 09:03:32 GMT
       Etag:
-      - '"a9302456857cb625cc506f0d91931095"'
+      - '"3c0769963328f864be3915461b60c257"'
       Location:
-      - https://api.contentful.com/spaces/3mf0acugjo3b
+      - https://api.contentful.com/spaces/h1elitsnp3wf
       Server:
       - nginx
       Status:
@@ -53,7 +55,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - 0b5-124658914
+      - 9e1-621570012
       Content-Length:
       - '456'
       Connection:
@@ -64,39 +66,39 @@ http_interactions:
         {
           "sys":{
             "type":"Space",
-            "id":"3mf0acugjo3b",
+            "id":"h1elitsnp3wf",
             "version":1,
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-18T15:24:58Z",
+            "createdAt":"2015-11-27T09:03:29Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-18T15:24:58Z"
+            "updatedAt":"2015-11-27T09:03:30Z"
           },
           "name":"gallery_space"
         }
 
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:24:59 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:33 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/author
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/author
     body:
       encoding: UTF-8
       string: '{"displayField":"name","name":"Author","description":null,"fields":[{"id":"name","name":"Name","type":"Symbol"}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -115,19 +117,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:00 GMT
+      - Fri, 27 Nov 2015 09:03:36 GMT
       Etag:
-      - '"53ad97862d4b6c7f98f9437242b4ec2a"'
+      - '"bf7e24f663e78d272ce61a46a61b8fa4"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -135,7 +137,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1hmIscOLqCYy6Og4osgUUQ
+      - content-api:1yEla3rHkMom4u6UuGwS4q
       X-Powered-By:
       - Express
       Content-Length:
@@ -162,42 +164,42 @@ http_interactions:
             "id": "author",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:00.609Z",
+            "createdAt": "2015-11-27T09:03:36.149Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
-            "updatedAt": "2015-11-18T15:25:00.609Z",
+            "updatedAt": "2015-11-27T09:03:36.149Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:00 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:37 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/author/published
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/author/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -220,19 +222,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:01 GMT
+      - Fri, 27 Nov 2015 09:03:40 GMT
       Etag:
-      - '"860421b5b6b2fbcbf4f4a7fde824b040"'
+      - '"dfdb3f1971e8bc57abb8aea9ab7fdb69"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -240,7 +242,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1CSe4DA3OYGWyIe066me4a
+      - content-api:38mxpHZueAemKEYaeWosWS
       X-Powered-By:
       - Express
       Content-Length:
@@ -266,54 +268,54 @@ http_interactions:
           "sys": {
             "id": "author",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:00.609Z",
+            "createdAt": "2015-11-27T09:03:36.149Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:01.368Z",
+            "updatedAt": "2015-11-27T09:03:39.751Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:01.368Z",
+            "firstPublishedAt": "2015-11-27T09:03:39.751Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:01.368Z",
+            "publishedAt": "2015-11-27T09:03:39.751Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:01 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:41 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/image
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/image
     body:
       encoding: UTF-8
       string: '{"displayField":"title","name":"Image","description":null,"fields":[{"id":"title","name":"Title","type":"Symbol"},{"id":"photo","name":"Photo","type":"Link","linkType":"Asset"}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -332,19 +334,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:02 GMT
+      - Fri, 27 Nov 2015 09:03:44 GMT
       Etag:
-      - '"245753954f8a59a385e93444dd72fdff"'
+      - '"7dd8e5a5bd15f575d8ae9bd8979120d7"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -352,7 +354,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3FjfaZgO3YsqQGKioGuCOY
+      - content-api:5bZenGXZC8MAWoowmu4Csc
       X-Powered-By:
       - Express
       Content-Length:
@@ -387,42 +389,42 @@ http_interactions:
             "id": "image",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:02.669Z",
+            "createdAt": "2015-11-27T09:03:44.212Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
-            "updatedAt": "2015-11-18T15:25:02.669Z",
+            "updatedAt": "2015-11-27T09:03:44.212Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:02 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:45 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/image/published
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/image/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -445,19 +447,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:04 GMT
+      - Fri, 27 Nov 2015 09:03:45 GMT
       Etag:
-      - '"da6be293c26a93109723b2a0a1148794"'
+      - '"0cdf343010a60c2c2d48938813149a45"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -465,7 +467,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2cg7WQQQPOS6YMm4i2ysys
+      - content-api:1GK5qZybSw2UCyIAq2igMo
       X-Powered-By:
       - Express
       Content-Length:
@@ -499,54 +501,54 @@ http_interactions:
           "sys": {
             "id": "image",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:02.669Z",
+            "createdAt": "2015-11-27T09:03:44.212Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:03.741Z",
+            "updatedAt": "2015-11-27T09:03:44.934Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:03.741Z",
+            "firstPublishedAt": "2015-11-27T09:03:44.934Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:03.741Z",
+            "publishedAt": "2015-11-27T09:03:44.934Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:03 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:47 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/gallery
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/gallery
     body:
       encoding: UTF-8
       string: '{"displayField":"title","name":"Gallery","description":null,"fields":[{"id":"title","name":"Title","type":"Symbol"},{"id":"author","name":"Author","type":"Link","linkType":"Entry"},{"id":"images","name":"Images","type":"Array","items":{"type":"Link","linkType":"Entry"}}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -565,19 +567,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:05 GMT
+      - Fri, 27 Nov 2015 09:03:46 GMT
       Etag:
-      - '"a1283dd9fff2676d9099139c43f07019"'
+      - '"3a5e45df9bf8efba84c415ff265baee2"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -585,7 +587,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:34MWFHwIpGKmgIsqIgOEGE
+      - content-api:3faV8YuUekmycyIwgc40w
       X-Powered-By:
       - Express
       Content-Length:
@@ -631,42 +633,42 @@ http_interactions:
             "id": "gallery",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:04.977Z",
+            "createdAt": "2015-11-27T09:03:46.365Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
-            "updatedAt": "2015-11-18T15:25:04.977Z",
+            "updatedAt": "2015-11-27T09:03:46.365Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:04 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:48 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/gallery/published
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/gallery/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -689,19 +691,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:05 GMT
+      - Fri, 27 Nov 2015 09:03:47 GMT
       Etag:
-      - '"9ad7361a5fd210c3ac30b94a72dfd985"'
+      - '"44dddaee5b2102453c604c2ab1af90c5"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -709,7 +711,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5qqhcqziRUQgGasukgIsKo
+      - content-api:12fAn33RCakgkiyo204SQm
       X-Powered-By:
       - Express
       Content-Length:
@@ -754,54 +756,54 @@ http_interactions:
           "sys": {
             "id": "gallery",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:04.977Z",
+            "createdAt": "2015-11-27T09:03:46.365Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:05.707Z",
+            "updatedAt": "2015-11-27T09:03:47.045Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:05.707Z",
+            "firstPublishedAt": "2015-11-27T09:03:47.045Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:05.707Z",
+            "publishedAt": "2015-11-27T09:03:47.045Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:05 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:49 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/assets/pie
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/assets/pie
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Pie in the Sky"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"pie.jpg","upload":"https://c2.staticflickr.com/6/5245/5335909339_d307a7cbcf_b.jpg"}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -820,19 +822,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:07 GMT
+      - Fri, 27 Nov 2015 09:03:48 GMT
       Etag:
-      - '"3cc2862e98645108d67ab4001c40c55c"'
+      - '"18c2e3e5138a143123ac549551974726"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -840,7 +842,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4XqFnW3Uqc2KAykIOWYAkm
+      - content-api:6XcOTT7s7CMwqO40myEAMq
       X-Powered-By:
       - Express
       Content-Length:
@@ -870,42 +872,42 @@ http_interactions:
             "id": "pie",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:06.965Z",
+            "createdAt": "2015-11-27T09:03:48.481Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
-            "updatedAt": "2015-11-18T15:25:06.965Z",
+            "updatedAt": "2015-11-27T09:03:48.481Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:06 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:50 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/assets/pie/files/en-US/process
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/assets/pie/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -928,17 +930,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:07 GMT
+      - Fri, 27 Nov 2015 09:03:49 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -946,7 +948,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4vc3Kb0fccYqq8G8ye0Mic
+      - content-api:420eyngAysM4sUWy2qcgIa
       X-Powered-By:
       - Express
       Connection:
@@ -955,16 +957,16 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:07 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:50 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/assets/pie
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/assets/pie
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -985,19 +987,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:08 GMT
+      - Fri, 27 Nov 2015 09:03:49 GMT
       Etag:
-      - '"9cbc6beb6865c2f541b4aba8d487df08"'
+      - '"39c90adbb96acb1e728c2d3e96799263"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1005,7 +1007,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6npCsapBcI0McA4k2kqYEi
+      - content-api:4TqMgtnQP6k6SEiEuGowak
       X-Powered-By:
       - Express
       Content-Length:
@@ -1034,50 +1036,50 @@ http_interactions:
                   },
                   "size": 266411
                 },
-                "url": "//images.contentful.com/3mf0acugjo3b/pie/759ff397fb8f53bd2a775af4dea1b13a/pie.jpg"
+                "url": "//images.contentful.com/h1elitsnp3wf/pie/9e531911cc9aa958724be3ff4c0834f8/pie.jpg"
               }
             }
           },
           "sys": {
             "id": "pie",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:06.965Z",
+            "createdAt": "2015-11-27T09:03:48.481Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:08.266Z",
+            "updatedAt": "2015-11-27T09:03:49.715Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:08 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:51 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/assets/pie/published
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/assets/pie/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1100,19 +1102,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:09 GMT
+      - Fri, 27 Nov 2015 09:03:50 GMT
       Etag:
-      - '"591239a9afc5948517a4830320ec41dd"'
+      - '"bda46341ca1d3fa887bec28edb50c35f"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1120,7 +1122,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:60ODhblNDOgEMSMIQS8Suu
+      - content-api:4RvexkFt6oIa0QYC8GCIkM
       X-Powered-By:
       - Express
       Content-Length:
@@ -1149,61 +1151,61 @@ http_interactions:
                   },
                   "size": 266411
                 },
-                "url": "//images.contentful.com/3mf0acugjo3b/pie/759ff397fb8f53bd2a775af4dea1b13a/pie.jpg"
+                "url": "//images.contentful.com/h1elitsnp3wf/pie/9e531911cc9aa958724be3ff4c0834f8/pie.jpg"
               }
             }
           },
           "sys": {
             "id": "pie",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:06.965Z",
+            "createdAt": "2015-11-27T09:03:48.481Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:09.437Z",
+            "updatedAt": "2015-11-27T09:03:50.461Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:09.437Z",
+            "firstPublishedAt": "2015-11-27T09:03:50.461Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:09.437Z",
+            "publishedAt": "2015-11-27T09:03:50.461Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:09 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:52 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/assets/flower
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/assets/flower
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"The Flower"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"flower.jpg","upload":"http://c2.staticflickr.com/4/3922/15045568809_b24591e318_b.jpg"}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1222,19 +1224,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:10 GMT
+      - Fri, 27 Nov 2015 09:03:51 GMT
       Etag:
-      - '"9741ed3cbe2831b266b481834e546706"'
+      - '"18ca40680a7a34fde7882ac11574c4db"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1242,7 +1244,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5j07LIKhlY80SwWGKc6cA6
+      - content-api:17NDMp4cyWIgIQgmYue2Wg
       X-Powered-By:
       - Express
       Content-Length:
@@ -1272,42 +1274,42 @@ http_interactions:
             "id": "flower",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:10.565Z",
+            "createdAt": "2015-11-27T09:03:51.509Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
-            "updatedAt": "2015-11-18T15:25:10.565Z",
+            "updatedAt": "2015-11-27T09:03:51.509Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:10 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:53 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/assets/flower/files/en-US/process
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/assets/flower/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1330,17 +1332,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:11 GMT
+      - Fri, 27 Nov 2015 09:03:52 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1348,7 +1350,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:657BpcgfwkKmew20qGgksy
+      - content-api:5vzwt3U2acIgs8u4aewkC2
       X-Powered-By:
       - Express
       Connection:
@@ -1357,16 +1359,16 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:11 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:53 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/assets/flower
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/assets/flower
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1387,19 +1389,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:12 GMT
+      - Fri, 27 Nov 2015 09:03:52 GMT
       Etag:
-      - '"477fdfcb4410d8b3a4c8014998fac3f2"'
+      - '"71a90721649d77965f8e09f376d915b0"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1407,7 +1409,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5TNtGp6N0IsKcAUWYyqW4w
+      - content-api:4oLbHNDOLeuyaoGIkEGg46
       X-Powered-By:
       - Express
       Content-Length:
@@ -1436,50 +1438,50 @@ http_interactions:
                   },
                   "size": 220335
                 },
-                "url": "//images.contentful.com/3mf0acugjo3b/flower/c5b779d8a1b434d470000803c3a7921c/flower.jpg"
+                "url": "//images.contentful.com/h1elitsnp3wf/flower/402662908c8ed2b16b63c504413d98ad/flower.jpg"
               }
             }
           },
           "sys": {
             "id": "flower",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:10.565Z",
+            "createdAt": "2015-11-27T09:03:51.509Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:11.825Z",
+            "updatedAt": "2015-11-27T09:03:52.798Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:11 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:54 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/assets/flower/published
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/assets/flower/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1502,19 +1504,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:12 GMT
+      - Fri, 27 Nov 2015 09:03:53 GMT
       Etag:
-      - '"8e66eabe866cd20ca98baf1f70e31922"'
+      - '"f31ae9d32f8b3e57d06285f951586a7d"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1522,7 +1524,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:cj4N9Ur1Icoq806mWAM4u
+      - content-api:6dSGKfxXI44UGa6US8c8m0
       X-Powered-By:
       - Express
       Content-Length:
@@ -1551,61 +1553,61 @@ http_interactions:
                   },
                   "size": 220335
                 },
-                "url": "//images.contentful.com/3mf0acugjo3b/flower/c5b779d8a1b434d470000803c3a7921c/flower.jpg"
+                "url": "//images.contentful.com/h1elitsnp3wf/flower/402662908c8ed2b16b63c504413d98ad/flower.jpg"
               }
             }
           },
           "sys": {
             "id": "flower",
             "type": "Asset",
-            "createdAt": "2015-11-18T15:25:10.565Z",
+            "createdAt": "2015-11-27T09:03:51.509Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:12.755Z",
+            "updatedAt": "2015-11-27T09:03:53.585Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:12.755Z",
+            "firstPublishedAt": "2015-11-27T09:03:53.585Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:12.755Z",
+            "publishedAt": "2015-11-27T09:03:53.585Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:12 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:55 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/author
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/author
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1626,19 +1628,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:13 GMT
+      - Fri, 27 Nov 2015 09:03:54 GMT
       Etag:
-      - '"be01be07e2718c06bd39db059e31aa9b"'
+      - '"5c1da887af5e9d0e98ea2daeb6e8b522"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1646,7 +1648,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2gpcpsZtKgYy2iMGAAGaiy
+      - content-api:3YQXne0FugGiO6kQcCamYU
       X-Powered-By:
       - Express
       Content-Length:
@@ -1672,54 +1674,54 @@ http_interactions:
           "sys": {
             "id": "author",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:00.609Z",
+            "createdAt": "2015-11-27T09:03:36.149Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:01.368Z",
+            "firstPublishedAt": "2015-11-27T09:03:39.751Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:01.368Z",
+            "publishedAt": "2015-11-27T09:03:39.751Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:01.395Z",
+            "updatedAt": "2015-11-27T09:03:39.794Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:13 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:55 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/dave
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/dave
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Dave"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1740,19 +1742,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:14 GMT
+      - Fri, 27 Nov 2015 09:03:55 GMT
       Etag:
-      - '"c64c0cdf7e891d70a224ca34911135e9"'
+      - '"e147b3426f3f207630560fd5fffdb624"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1760,39 +1762,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5QKwpyN3na22IuaCQweeK4
+      - content-api:1Vfs8KBL5eOYesMK4eeG8
       X-Powered-By:
       - Express
       Content-Length:
-      - '766'
+      - '721'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Dave"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "dave",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:14.369Z",
+            "createdAt": "2015-11-27T09:03:55.233Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -1802,27 +1800,27 @@ http_interactions:
                 "id": "author"
               }
             },
-            "updatedAt": "2015-11-18T15:25:14.369Z",
+            "updatedAt": "2015-11-27T09:03:55.233Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:14 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:56 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/dave
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/dave
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Dave"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1843,19 +1841,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:15 GMT
+      - Fri, 27 Nov 2015 09:03:56 GMT
       Etag:
-      - '"e93e7069396ba2dee5e9a6b2ecf7a844"'
+      - '"dae2ccebd053bca31bc90bdb5cbb606b"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1863,38 +1861,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:y09YlNyfSgysIkuey686a
+      - content-api:5B5aGcLLl6esGSICg2Q0w8
       X-Powered-By:
       - Express
       Content-Length:
-      - '766'
+      - '721'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Dave"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "dave",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:25:14.369Z",
+            "createdAt": "2015-11-27T09:03:55.233Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -1905,27 +1899,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:15.183Z",
+            "updatedAt": "2015-11-27T09:03:56.572Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:15 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:58 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/image
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -1946,19 +1940,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:15 GMT
+      - Fri, 27 Nov 2015 09:03:57 GMT
       Etag:
-      - '"2eb03b73fc23f014edbcf991b7eb11cb"'
+      - '"4b07b0cc0e4d6d0f4207e41d152c5e19"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1966,7 +1960,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7AAUxkJpCgQ22Qoi28Mmy2
+      - content-api:1DrLodkT0cIcwMuSgWEcYg
       X-Powered-By:
       - Express
       Content-Length:
@@ -2000,54 +1994,54 @@ http_interactions:
           "sys": {
             "id": "image",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:02.669Z",
+            "createdAt": "2015-11-27T09:03:44.212Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:03.741Z",
+            "firstPublishedAt": "2015-11-27T09:03:44.934Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:03.741Z",
+            "publishedAt": "2015-11-27T09:03:44.934Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:03.771Z",
+            "updatedAt": "2015-11-27T09:03:44.987Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:15 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:58 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/pie_entry
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/pie_entry
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"A Pie in the Sky"},"photo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"pie"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2068,19 +2062,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:16 GMT
+      - Fri, 27 Nov 2015 09:03:58 GMT
       Etag:
-      - '"b4a373679ce0a7f8cc86d73a233dca60"'
+      - '"ee1c9b7bc41ee16d45e223d168165224"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2088,48 +2082,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2Tz9g4BWhWM8gmU2MIuUwg
+      - content-api:18SZcpe0DIWaUAKsqeQ0Cc
       X-Powered-By:
       - Express
       Content-Length:
-      - '936'
+      - '725'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "A Pie in the Sky"
-            },
-            "photo": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "pie"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "pie_entry",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:16.893Z",
+            "createdAt": "2015-11-27T09:03:58.048Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -2139,27 +2120,27 @@ http_interactions:
                 "id": "image"
               }
             },
-            "updatedAt": "2015-11-18T15:25:16.893Z",
+            "updatedAt": "2015-11-27T09:03:58.048Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:16 GMT
+  recorded_at: Fri, 27 Nov 2015 09:03:59 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/pie_entry
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/pie_entry
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"A Pie in the Sky"},"photo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"pie"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2180,19 +2161,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:17 GMT
+      - Fri, 27 Nov 2015 09:03:59 GMT
       Etag:
-      - '"514149ebdd477abfe55f812ab8c59fa5"'
+      - '"b62e1b6720dff4463a9e4cc13aadb93b"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2200,47 +2181,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4OtwsIQtNCEQaKWcSgcqO2
+      - content-api:1GoCAv2SGAgqiAUEwegsI
       X-Powered-By:
       - Express
       Content-Length:
-      - '936'
+      - '725'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "A Pie in the Sky"
-            },
-            "photo": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "pie"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "pie_entry",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:25:16.893Z",
+            "createdAt": "2015-11-27T09:03:58.048Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -2251,27 +2219,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:17.889Z",
+            "updatedAt": "2015-11-27T09:03:59.013Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:17 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:00 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/flower_entry
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/flower_entry
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"The Flower"},"photo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"flower"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2292,19 +2260,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:18 GMT
+      - Fri, 27 Nov 2015 09:04:00 GMT
       Etag:
-      - '"1bc2998fcc13bb1b3fe35136dadf5c3d"'
+      - '"f54c240f87ac518e0a26678acc24ba5e"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2312,48 +2280,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6ixwUhF4n6K4swqQugiKGI
+      - content-api:2ixnUp79Is0OUqAoimawCO
       X-Powered-By:
       - Express
       Content-Length:
-      - '936'
+      - '728'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "The Flower"
-            },
-            "photo": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "flower"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "flower_entry",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:18.893Z",
+            "createdAt": "2015-11-27T09:03:59.949Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -2363,27 +2318,27 @@ http_interactions:
                 "id": "image"
               }
             },
-            "updatedAt": "2015-11-18T15:25:18.893Z",
+            "updatedAt": "2015-11-27T09:03:59.949Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:18 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:01 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/flower_entry
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/flower_entry
     body:
       encoding: UTF-8
-      string: '{"fields":{"title":{"en-US":"The Flower"},"photo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"flower"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2404,19 +2359,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:19 GMT
+      - Fri, 27 Nov 2015 09:04:01 GMT
       Etag:
-      - '"efa464f0569a8fdecd3861f656dadaef"'
+      - '"bfebc5366fa04978bf52e4aee57e188a"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2424,47 +2379,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3mHwSEyIe4k6M6C22kQYWu
+      - content-api:67ePyWTdkIU02CsYseqy2m
       X-Powered-By:
       - Express
       Content-Length:
-      - '936'
+      - '728'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "title": {
-              "en-US": "The Flower"
-            },
-            "photo": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Asset",
-                  "id": "flower"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "flower_entry",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:25:18.893Z",
+            "createdAt": "2015-11-27T09:03:59.949Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -2475,27 +2417,27 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:19.909Z",
+            "updatedAt": "2015-11-27T09:04:00.952Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:19 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:02 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/content_types/gallery
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/content_types/gallery
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2516,19 +2458,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:20 GMT
+      - Fri, 27 Nov 2015 09:04:01 GMT
       Etag:
-      - '"bb68a1140b3ee9f65c26222e1fe9782e"'
+      - '"cad8496bd3c91d1754f7ab423ea8b42d"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2536,7 +2478,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1T3Kh9dDXSacYukQY0y2a8
+      - content-api:6mvLEZLpF6ukq2yKek2e0I
       X-Powered-By:
       - Express
       Content-Length:
@@ -2581,55 +2523,54 @@ http_interactions:
           "sys": {
             "id": "gallery",
             "type": "ContentType",
-            "createdAt": "2015-11-18T15:25:04.977Z",
+            "createdAt": "2015-11-27T09:03:46.365Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:05.707Z",
+            "firstPublishedAt": "2015-11-27T09:03:47.045Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:05.707Z",
+            "publishedAt": "2015-11-27T09:03:47.045Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:05.733Z",
+            "updatedAt": "2015-11-27T09:03:47.099Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:20 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:03 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/gallery
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/gallery
     body:
       encoding: UTF-8
-      string: '{"fields":{"images":{"en-US":[{"sys":{"type":"Link","linkType":"Entry","id":"pie_entry"}},{"sys":{"type":"Link","linkType":"Entry","id":"flower_entry"}}]},"title":{"en-US":"Photo
-        Gallery"},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"dave"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2650,19 +2591,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:21 GMT
+      - Fri, 27 Nov 2015 09:04:03 GMT
       Etag:
-      - '"27363d0b078aa7679a917ad394e385ac"'
+      - '"20e9eeeae4afc17ffe1dfb97283ef58b"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2670,66 +2611,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2xRwCf98LWaK42gCGeOUsy
+      - content-api:2WTHxxT5v2wsKYoasSQW4s
       X-Powered-By:
       - Express
       Content-Length:
-      - '1271'
+      - '725'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "images": {
-              "en-US": [
-                {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Entry",
-                    "id": "pie_entry"
-                  }
-                },
-                {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Entry",
-                    "id": "flower_entry"
-                  }
-                }
-              ]
-            },
-            "title": {
-              "en-US": "Photo Gallery"
-            },
-            "author": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "dave"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "gallery",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T15:25:21.608Z",
+            "createdAt": "2015-11-27T09:04:03.309Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -2739,28 +2649,27 @@ http_interactions:
                 "id": "gallery"
               }
             },
-            "updatedAt": "2015-11-18T15:25:21.608Z",
+            "updatedAt": "2015-11-27T09:04:03.309Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:21 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:05 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/gallery
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/gallery
     body:
       encoding: UTF-8
-      string: '{"fields":{"images":{"en-US":[{"sys":{"type":"Link","linkType":"Entry","id":"pie_entry"}},{"sys":{"type":"Link","linkType":"Entry","id":"flower_entry"}}]},"title":{"en-US":"Photo
-        Gallery"},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"dave"}}}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -2781,19 +2690,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:22 GMT
+      - Fri, 27 Nov 2015 09:04:04 GMT
       Etag:
-      - '"f2fbeb088c802ef07bbc3205a77b2dfe"'
+      - '"0363bf54735bad444bf7ca507084ed9a"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2801,65 +2710,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5lgIZhExbiC2YssSKGOUYc
+      - content-api:1mYcoYMWlmE6CQumQKoo22
       X-Powered-By:
       - Express
       Content-Length:
-      - '1271'
+      - '725'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "images": {
-              "en-US": [
-                {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Entry",
-                    "id": "pie_entry"
-                  }
-                },
-                {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Entry",
-                    "id": "flower_entry"
-                  }
-                }
-              ]
-            },
-            "title": {
-              "en-US": "Photo Gallery"
-            },
-            "author": {
-              "en-US": {
-                "sys": {
-                  "type": "Link",
-                  "linkType": "Entry",
-                  "id": "dave"
-                }
-              }
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "gallery",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:25:21.608Z",
+            "createdAt": "2015-11-27T09:04:03.309Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -2870,144 +2748,31 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T15:25:22.604Z",
+            "updatedAt": "2015-11-27T09:04:04.281Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:22 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:05 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries?content_type=author
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/dave
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      Connection:
-      - close
-      Host:
-      - api.contentful.com
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
-      Access-Control-Allow-Methods:
-      - DELETE,GET,HEAD,POST,PUT,OPTIONS
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Etag
-      Access-Control-Max-Age:
-      - '1728000'
-      Cf-Space-Id:
-      - 3mf0acugjo3b
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      Date:
-      - Wed, 18 Nov 2015 15:25:23 GMT
-      Etag:
-      - '"97888497d72480ad7e3451dd4442b40b"'
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Content-Type-Options:
-      - nosniff
-      X-Contentful-Request-Id:
-      - content-api:61huRFUFjOaAE44YceogUk
-      X-Powered-By:
-      - Express
-      Content-Length:
-      - '1034'
-      Connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "sys": {
-            "type": "Array"
-          },
-          "total": 1,
-          "skip": 0,
-          "limit": 100,
-          "items": [
-            {
-              "fields": {
-                "name": {
-                  "en-US": "Dave"
-                }
-              },
-              "sys": {
-                "id": "dave",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:25:14.369Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "3mf0acugjo3b"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "author"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:25:15.243Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:23 GMT
-- request:
-    method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/dave/published
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RubyContentfulManagementGem/0.7.2
-      Authorization:
-      - Bearer foobar
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -3024,19 +2789,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:24 GMT
+      - Fri, 27 Nov 2015 09:04:04 GMT
       Etag:
-      - '"ed8fcbf826958f9bd402d3fce07d137e"'
+      - '"5c22a76167cf8078b549e83c2e0b826d"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3044,11 +2809,110 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7i1y0683AIw8YwE8ge0Wu0
+      - content-api:S4WUOhb3uUcwcuosg0AEG
       X-Powered-By:
       - Express
       Content-Length:
-      - '1061'
+      - '721'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "dave",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:55.233Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:03:56.618Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:06 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/dave
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Dave"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:05 GMT
+      Etag:
+      - '"eee74c83673457d1f8e65f8feacee6ea"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4QusSfPaSke4cgo4YgwsGg
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '766'
       Connection:
       - Close
     body:
@@ -3063,19 +2927,19 @@ http_interactions:
           "sys": {
             "id": "dave",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:25:14.369Z",
+            "createdAt": "2015-11-27T09:03:55.233Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -3086,42 +2950,33 @@ http_interactions:
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:24.039Z",
+            "updatedAt": "2015-11-27T09:04:05.891Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
-            },
-            "firstPublishedAt": "2015-11-18T15:25:24.039Z",
-            "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:24.039Z",
-            "publishedBy": {
-              "sys": {
-                "type": "Link",
-                "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
-              }
-            },
-            "publishedVersion": 2
+            }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:24 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:07 GMT
 - request:
-    method: get
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries?content_type=image
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/dave
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Dave"}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
       Connection:
       - close
       Host:
@@ -3136,19 +2991,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:24 GMT
+      - Fri, 27 Nov 2015 09:04:06 GMT
       Etag:
-      - '"446cebb0e3905e338aa502c9ce295801"'
+      - '"636f63fec846b1ea908b3f188f7f091e"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3156,145 +3011,73 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3wP9pXq1scQESgiwq6QQiI
+      - content-api:408mzWDppegGksMKIm0Acs
       X-Powered-By:
       - Express
       Content-Length:
-      - '2381'
+      - '766'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "sys": {
-            "type": "Array"
+          "fields": {
+            "name": {
+              "en-US": "Dave"
+            }
           },
-          "total": 2,
-          "skip": 0,
-          "limit": 100,
-          "items": [
-            {
-              "fields": {
-                "title": {
-                  "en-US": "The Flower"
-                },
-                "photo": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Asset",
-                      "id": "flower"
-                    }
-                  }
-                }
-              },
+          "sys": {
+            "id": "dave",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:55.233Z",
+            "createdBy": {
               "sys": {
-                "id": "flower_entry",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:25:18.893Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "3mf0acugjo3b"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "image"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:25:19.953Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            {
-              "fields": {
-                "title": {
-                  "en-US": "A Pie in the Sky"
-                },
-                "photo": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Asset",
-                      "id": "pie"
-                    }
-                  }
-                }
-              },
+            "space": {
               "sys": {
-                "id": "pie_entry",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:25:16.893Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "3mf0acugjo3b"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "image"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:25:17.933Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:06.893Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
-          ]
+          }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:24 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:08 GMT
 - request:
-    method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/flower_entry/published
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/dave
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -3311,19 +3094,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:25 GMT
+      - Fri, 27 Nov 2015 09:04:07 GMT
       Etag:
-      - '"06b66339717a735fbd462f21c96b5b81"'
+      - '"e2b3ccd2e7299d358f16913784edc029"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3331,11 +3114,648 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6y1srME85qAMSMUQGccO8W
+      - content-api:4Psj7HxNBeAS2aqyQ4E4aY
       X-Powered-By:
       - Express
       Content-Length:
-      - '1231'
+      - '766'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Dave"
+            }
+          },
+          "sys": {
+            "id": "dave",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:55.233Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:06.943Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:09 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/pie_entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:08 GMT
+      Etag:
+      - '"cbbcefa044271e45c328cc88e26a9215"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:59aoK80qTuEcsueWg2OoCg
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '725'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "pie_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:58.048Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:03:59.063Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:09 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/pie_entry
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"A Pie in the Sky"},"photo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"pie"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:09 GMT
+      Etag:
+      - '"b71afd0615abc9b3992f33366f88f5e5"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:7a81pz2EWk0KuUSkgg0imI
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '936'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "A Pie in the Sky"
+            },
+            "photo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "pie"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "pie_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:58.048Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:04:09.053Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:10 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/pie_entry
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"A Pie in the Sky"},"photo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"pie"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:10 GMT
+      Etag:
+      - '"7a7b9cdae1fd7a3dd6528d4b353bbff5"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:2b80K6IeOgaYioEwECuiQC
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '936'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "A Pie in the Sky"
+            },
+            "photo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "pie"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "pie_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:58.048Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:09.995Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:11 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/pie_entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:10 GMT
+      Etag:
+      - '"219a2d00690e526b8664d3098b5ad1ec"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3MhrWmU9OMweE4YOaGucCO
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '936'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "A Pie in the Sky"
+            },
+            "photo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "pie"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "pie_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:58.048Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:10.041Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:12 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/flower_entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:11 GMT
+      Etag:
+      - '"5e9a532e6f0dad393355c6a57eb04416"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3K7g7y89XWi20cqOmgi04q
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '728'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "flower_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:59.949Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:04:00.998Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:12 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/flower_entry
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"The Flower"},"photo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"flower"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:12 GMT
+      Etag:
+      - '"f6505fdfe56c56d372b938ddf933aad4"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4SlALk1y1WIkiysK2WSYWo
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '936'
       Connection:
       - Close
     body:
@@ -3359,19 +3779,19 @@ http_interactions:
           "sys": {
             "id": "flower_entry",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:25:18.893Z",
+            "createdAt": "2015-11-27T09:03:59.949Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -3382,44 +3802,143 @@ http_interactions:
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T15:25:25.589Z",
+            "updatedAt": "2015-11-27T09:04:12.093Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
-            },
-            "firstPublishedAt": "2015-11-18T15:25:25.589Z",
-            "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:25.589Z",
-            "publishedBy": {
-              "sys": {
-                "type": "Link",
-                "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
-              }
-            },
-            "publishedVersion": 2
+            }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:25 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:13 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/pie_entry/published
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/flower_entry
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"fields":{"title":{"en-US":"The Flower"},"photo":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"flower"}}}}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
       X-Contentful-Version:
-      - '2'
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:13 GMT
+      Etag:
+      - '"a547094e85fdc795bfd47b3166cc49b0"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:28hzmEaqW4iCu4qYqCokUo
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '936'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "The Flower"
+            },
+            "photo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "flower"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "flower_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:59.949Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:13.076Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:14 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/flower_entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
       Content-Length:
       - '0'
       Connection:
@@ -3436,19 +3955,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:26 GMT
+      - Fri, 27 Nov 2015 09:04:13 GMT
       Etag:
-      - '"1e178fb769d83e3cb9c2fba6c2edf9c8"'
+      - '"be0f9a23e7ce9a3ae0bbf0aac766e1c8"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3456,7 +3975,943 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:72ea0eSNMsyUmW6gSakQkc
+      - content-api:1Q3mu4KtZOSUmY80sewsG2
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '936'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "The Flower"
+            },
+            "photo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "flower"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "flower_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:59.949Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:13.123Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:15 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/gallery
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:14 GMT
+      Etag:
+      - '"3b026b1d12b86f1e52b0a49d03a9e766"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1ty2rTUpXagm6iIEySW2Q6
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '725'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "gallery",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:04:03.309Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "gallery"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-27T09:04:04.331Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:15 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/gallery
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"images":{"en-US":[{"sys":{"type":"Link","linkType":"Entry","id":"pie_entry"}},{"sys":{"type":"Link","linkType":"Entry","id":"flower_entry"}}]},"title":{"en-US":"Photo
+        Gallery"},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"dave"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:15 GMT
+      Etag:
+      - '"e38c96043c016843589f7270ba0ebeaf"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5YaRL1vVjUKYIKwoeM4Kky
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1271'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "images": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "pie_entry"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "flower_entry"
+                  }
+                }
+              ]
+            },
+            "title": {
+              "en-US": "Photo Gallery"
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "dave"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "gallery",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:04:03.309Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "gallery"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-11-27T09:04:15.216Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:16 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/gallery
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"images":{"en-US":[{"sys":{"type":"Link","linkType":"Entry","id":"pie_entry"}},{"sys":{"type":"Link","linkType":"Entry","id":"flower_entry"}}]},"title":{"en-US":"Photo
+        Gallery"},"author":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"dave"}}}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:16 GMT
+      Etag:
+      - '"070bc40af1a9676e262fd17be989a55a"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:58YPFRP7O8Eu4oqsUswuyG
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1271'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "images": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "pie_entry"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "flower_entry"
+                  }
+                }
+              ]
+            },
+            "title": {
+              "en-US": "Photo Gallery"
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "dave"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "gallery",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:04:03.309Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "gallery"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:16.157Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:17 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/gallery
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:16 GMT
+      Etag:
+      - '"4c8c1e705b3d9c94b017bcf0c6f915e9"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1HiouPPirq4miMQk0Sqyq2
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1271'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "images": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "pie_entry"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "flower_entry"
+                  }
+                }
+              ]
+            },
+            "title": {
+              "en-US": "Photo Gallery"
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "dave"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "gallery",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:04:03.309Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "gallery"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:16.211Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:18 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/dave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:17 GMT
+      Etag:
+      - '"e2b3ccd2e7299d358f16913784edc029"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:zlsuKkGMLIauq6QmmmO0e
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '766'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Dave"
+            }
+          },
+          "sys": {
+            "id": "dave",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:55.233Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:06.943Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:19 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/dave/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:18 GMT
+      Etag:
+      - '"ad98df8426239ac082dc3c4353f2914b"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:43jlsoOtlms8ME4eay06wc
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1061'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Dave"
+            }
+          },
+          "sys": {
+            "id": "dave",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:55.233Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "author"
+              }
+            },
+            "version": 5,
+            "updatedAt": "2015-11-27T09:04:18.025Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "firstPublishedAt": "2015-11-27T09:04:18.025Z",
+            "publishedCounter": 1,
+            "publishedAt": "2015-11-27T09:04:18.025Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "publishedVersion": 4
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:19 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/pie_entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:18 GMT
+      Etag:
+      - '"219a2d00690e526b8664d3098b5ad1ec"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:ykKCO5x1hmsAKAOoMwGaK
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '936'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "A Pie in the Sky"
+            },
+            "photo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "pie"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "pie_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:58.048Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:10.041Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:20 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/pie_entry/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:19 GMT
+      Etag:
+      - '"6b22e786f338fc1464cb11140ee01788"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1dlrF3cTHCUAW24gyS2ck0
       X-Powered-By:
       - Express
       Content-Length:
@@ -3484,19 +4939,19 @@ http_interactions:
           "sys": {
             "id": "pie_entry",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:25:16.893Z",
+            "createdAt": "2015-11-27T09:03:58.048Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -3506,183 +4961,43 @@ http_interactions:
                 "id": "image"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:25:26.440Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:04:19.454Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:26.440Z",
+            "firstPublishedAt": "2015-11-27T09:04:19.454Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:26.440Z",
+            "publishedAt": "2015-11-27T09:04:19.454Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:26 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:21 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries?content_type=gallery
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/flower_entry
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
-      Connection:
-      - close
-      Host:
-      - api.contentful.com
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
-      Access-Control-Allow-Methods:
-      - DELETE,GET,HEAD,POST,PUT,OPTIONS
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Etag
-      Access-Control-Max-Age:
-      - '1728000'
-      Cf-Space-Id:
-      - 3mf0acugjo3b
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      Date:
-      - Wed, 18 Nov 2015 15:25:27 GMT
-      Etag:
-      - '"17dee285d64c9828ac13f6e146221e48"'
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=15768000
-      X-Content-Type-Options:
-      - nosniff
-      X-Contentful-Request-Id:
-      - content-api:66aPkepkD62OumY4i04kCG
-      X-Powered-By:
-      - Express
-      Content-Length:
-      - '1647'
-      Connection:
-      - Close
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "sys": {
-            "type": "Array"
-          },
-          "total": 1,
-          "skip": 0,
-          "limit": 100,
-          "items": [
-            {
-              "fields": {
-                "images": {
-                  "en-US": [
-                    {
-                      "sys": {
-                        "type": "Link",
-                        "linkType": "Entry",
-                        "id": "pie_entry"
-                      }
-                    },
-                    {
-                      "sys": {
-                        "type": "Link",
-                        "linkType": "Entry",
-                        "id": "flower_entry"
-                      }
-                    }
-                  ]
-                },
-                "title": {
-                  "en-US": "Photo Gallery"
-                },
-                "author": {
-                  "en-US": {
-                    "sys": {
-                      "type": "Link",
-                      "linkType": "Entry",
-                      "id": "dave"
-                    }
-                  }
-                }
-              },
-              "sys": {
-                "id": "gallery",
-                "type": "Entry",
-                "createdAt": "2015-11-18T15:25:21.608Z",
-                "createdBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                },
-                "space": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Space",
-                    "id": "3mf0acugjo3b"
-                  }
-                },
-                "contentType": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "ContentType",
-                    "id": "gallery"
-                  }
-                },
-                "version": 2,
-                "updatedAt": "2015-11-18T15:25:22.650Z",
-                "updatedBy": {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "User",
-                    "id": "4SejVrWT96dvL9IV4Nb7sQ"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:27 GMT
-- request:
-    method: put
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/entries/gallery/published
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - RubyContentfulManagementGem/0.7.2
-      Authorization:
-      - Bearer foobar
-      Content-Type:
-      - application/vnd.contentful.management.v1+json
-      X-Contentful-Version:
-      - '2'
       Content-Length:
       - '0'
       Connection:
@@ -3699,19 +5014,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - 3mf0acugjo3b
+      - h1elitsnp3wf
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:28 GMT
+      - Fri, 27 Nov 2015 09:04:20 GMT
       Etag:
-      - '"866770a54adbc0e027240fd34058f034"'
+      - '"be0f9a23e7ce9a3ae0bbf0aac766e1c8"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -3719,7 +5034,376 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4qFPJ5pm1GeCEUs86eMMYm
+      - content-api:hhGxf6MBfGE6UYcmmiA4M
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '936'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "The Flower"
+            },
+            "photo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "flower"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "flower_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:59.949Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:13.123Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:21 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/flower_entry/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:21 GMT
+      Etag:
+      - '"0105037503a957eee6ad64c5657e71a5"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:6RR9jIiEaAWUoYcEo06sy8
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1231'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "title": {
+              "en-US": "The Flower"
+            },
+            "photo": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "id": "flower"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "flower_entry",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:03:59.949Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "image"
+              }
+            },
+            "version": 5,
+            "updatedAt": "2015-11-27T09:04:20.868Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "firstPublishedAt": "2015-11-27T09:04:20.868Z",
+            "publishedCounter": 1,
+            "publishedAt": "2015-11-27T09:04:20.868Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "publishedVersion": 4
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:22 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/gallery
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:21 GMT
+      Etag:
+      - '"4c8c1e705b3d9c94b017bcf0c6f915e9"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3rY2mllO4MQmsCYUMgUsAq
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1271'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "images": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "pie_entry"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "flower_entry"
+                  }
+                }
+              ]
+            },
+            "title": {
+              "en-US": "Photo Gallery"
+            },
+            "author": {
+              "en-US": {
+                "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "dave"
+                }
+              }
+            }
+          },
+          "sys": {
+            "id": "gallery",
+            "type": "Entry",
+            "createdAt": "2015-11-27T09:04:03.309Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "h1elitsnp3wf"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "gallery"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-27T09:04:16.211Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Fri, 27 Nov 2015 09:04:23 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/entries/gallery/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - h1elitsnp3wf
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Fri, 27 Nov 2015 09:04:22 GMT
+      Etag:
+      - '"dcd775dba5de821bcae49f243a9a6d5d"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:7lFDALbB1SQc0kU8ccIuqc
       X-Powered-By:
       - Express
       Content-Length:
@@ -3765,19 +5449,19 @@ http_interactions:
           "sys": {
             "id": "gallery",
             "type": "Entry",
-            "createdAt": "2015-11-18T15:25:21.608Z",
+            "createdAt": "2015-11-27T09:04:03.309Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "3mf0acugjo3b"
+                "id": "h1elitsnp3wf"
               }
             },
             "contentType": {
@@ -3787,40 +5471,40 @@ http_interactions:
                 "id": "gallery"
               }
             },
-            "version": 3,
-            "updatedAt": "2015-11-18T15:25:28.025Z",
+            "version": 5,
+            "updatedAt": "2015-11-27T09:04:22.706Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T15:25:28.025Z",
+            "firstPublishedAt": "2015-11-27T09:04:22.706Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T15:25:28.025Z",
+            "publishedAt": "2015-11-27T09:04:22.706Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "publishedVersion": 2
+            "publishedVersion": 4
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:28 GMT
+  recorded_at: Fri, 27 Nov 2015 09:04:24 GMT
 - request:
     method: post
-    uri: https://api.contentful.com/spaces/3mf0acugjo3b/api_keys
+    uri: https://api.contentful.com/spaces/h1elitsnp3wf/api_keys
     body:
       encoding: UTF-8
       string: '{"name":"Bootstrap Token","description":"Created with ''contentful_bootstrap.rb
         v2.0.2''"}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -3841,7 +5525,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -3851,11 +5535,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 15:25:29 GMT
+      - Fri, 27 Nov 2015 09:04:23 GMT
       Etag:
-      - '"e5f2cff48490ee040dbc8e9bcd7174df"'
+      - '"c856dff55631a898f4d37ba46cfedac1"'
       Location:
-      - https://api.contentful.com/spaces/3mf0acugjo3b/api_keys/44UMHOPNDsD0QkBxqVVWte
+      - https://api.contentful.com/spaces/h1elitsnp3wf/api_keys/63eg8gkuq2UGgSjavehGTv
       Server:
       - nginx
       Status:
@@ -3865,7 +5549,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - b89-1468507108
+      - 9e1-621570440
       Content-Length:
       - '954'
       Connection:
@@ -3876,35 +5560,35 @@ http_interactions:
         {
           "sys":{
             "type":"ApiKey",
-            "id":"44UMHOPNDsD0QkBxqVVWte",
+            "id":"63eg8gkuq2UGgSjavehGTv",
             "version":0,
             "space":{
               "sys":{
                 "type":"Link",
                 "linkType":"Space",
-                "id":"3mf0acugjo3b"
+                "id":"h1elitsnp3wf"
               }
             },
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-18T15:25:29Z",
+            "createdAt":"2015-11-27T09:04:23Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-18T15:25:29Z"
+            "updatedAt":"2015-11-27T09:04:23Z"
           },
           "name":"Bootstrap Token",
           "description":"Created with 'contentful_bootstrap.rb v2.0.2'",
-          "accessToken":"c85f6fe587a9f01850e3464c1ec5c09494e653c1cbf57d91e6aa2ec03fbd38ae",
+          "accessToken":"47796a104c137afca9b29912947f8c22e4fcdd398c0c646336cef49bbbe38d18",
           "policies":[
             {
               "effect":"allow",
@@ -3915,11 +5599,11 @@ http_interactions:
             "sys":{
               "type":"Link",
               "linkType":"PreviewApiKey",
-              "id":"44VWHEBmfng2mzKizh5VT6"
+              "id":"63feXrQjkeNZlGIdGJ5y9P"
             }
           }
         }
 
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 15:25:29 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Fri, 27 Nov 2015 09:04:25 GMT
+recorded_with: VCR 3.0.0

--- a/spec/fixtures/vcr_fixtures/issue_22.yml
+++ b/spec/fixtures/vcr_fixtures/issue_22.yml
@@ -13,6 +13,8 @@ http_interactions:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
+      X-Contentful-Organization:
+      - 1PLOOEmTI2S1NYald2TemO
       Connection:
       - close
       Host:
@@ -29,7 +31,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -39,11 +41,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:20:57 GMT
+      - Mon, 23 Nov 2015 10:10:00 GMT
       Etag:
-      - '"f4fc7884a50f2e24116f49f2cbc11e22"'
+      - '"b400259b3e539ea3d2fff426cc3b3be2"'
       Location:
-      - https://api.contentful.com/spaces/wbtalxpseprz
+      - https://api.contentful.com/spaces/8rbh6yfkme6s
       Server:
       - nginx
       Status:
@@ -53,7 +55,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - b89-1468408633
+      - 9e1-618763834
       Content-Length:
       - '451'
       Connection:
@@ -64,33 +66,33 @@ http_interactions:
         {
           "sys":{
             "type":"Space",
-            "id":"wbtalxpseprz",
+            "id":"8rbh6yfkme6s",
             "version":1,
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-18T12:20:57Z",
+            "createdAt":"2015-11-23T10:09:57Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-18T12:20:57Z"
+            "updatedAt":"2015-11-23T10:09:57Z"
           },
           "name":"issue_22"
         }
 
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:20:57 GMT
+  recorded_at: Mon, 23 Nov 2015 10:09:59 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/content_types/1VX60jHERm6yuem8I2agWG
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/content_types/1VX60jHERm6yuem8I2agWG
     body:
       encoding: UTF-8
       string: '{"displayField":"title","name":"yolo","description":null,"fields":[{"id":"title","name":"title","type":"Symbol"},{"id":"assets","name":"assets","type":"Array","items":{"type":"Link","linkType":"Asset"}}]}'
@@ -115,19 +117,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:20:59 GMT
+      - Mon, 23 Nov 2015 10:10:04 GMT
       Etag:
-      - '"e8a357ce998307b38e426765b46a2a2b"'
+      - '"81e8635fbe7283d5f4bf2af63cb87be5"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -135,7 +137,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:19f8RrtM8OkSiSmeAocO2g
+      - content-api:3CqpjytXluOwOcwkU0oCUi
       X-Powered-By:
       - Express
       Content-Length:
@@ -173,36 +175,36 @@ http_interactions:
             "id": "1VX60jHERm6yuem8I2agWG",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-18T12:20:59.205Z",
+            "createdAt": "2015-11-23T10:10:04.310Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
-            "updatedAt": "2015-11-18T12:20:59.206Z",
+            "updatedAt": "2015-11-23T10:10:04.310Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:20:59 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:03 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/content_types/1VX60jHERm6yuem8I2agWG/published
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/content_types/1VX60jHERm6yuem8I2agWG/published
     body:
       encoding: US-ASCII
       string: ''
@@ -231,19 +233,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:00 GMT
+      - Mon, 23 Nov 2015 10:10:08 GMT
       Etag:
-      - '"b57191984ce3ba2558afa0f684557c65"'
+      - '"eb776563a19da9302c3ab724971db63b"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -251,7 +253,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3sBXBSwPCMyqo4McQaK2Ca
+      - content-api:585JB17hy0SkMsmiQAq66O
       X-Powered-By:
       - Express
       Content-Length:
@@ -288,48 +290,48 @@ http_interactions:
           "sys": {
             "id": "1VX60jHERm6yuem8I2agWG",
             "type": "ContentType",
-            "createdAt": "2015-11-18T12:20:59.205Z",
+            "createdAt": "2015-11-23T10:10:04.310Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T12:21:00.054Z",
+            "updatedAt": "2015-11-23T10:10:08.012Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T12:21:00.054Z",
+            "firstPublishedAt": "2015-11-23T10:10:08.012Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T12:21:00.054Z",
+            "publishedAt": "2015-11-23T10:10:08.012Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:00 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:07 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/2cMU9UUngYMqAEmw4Cm8Iw
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/2cMU9UUngYMqAEmw4Cm8Iw
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Screen Shot 2015-11-18 at 11.42.12"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"Screen
@@ -355,19 +357,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:01 GMT
+      - Mon, 23 Nov 2015 10:10:09 GMT
       Etag:
-      - '"0cb47fefce1f00a632226404960a648a"'
+      - '"987dfc426127013fa8b72c978eb42bb1"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -375,7 +377,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1QlDr6SSEQkU28M0Eo8uES
+      - content-api:5x2HIuEO2Ikm8Yi0yU4Q6S
       X-Powered-By:
       - Express
       Content-Length:
@@ -405,36 +407,36 @@ http_interactions:
             "id": "2cMU9UUngYMqAEmw4Cm8Iw",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T12:21:01.356Z",
+            "createdAt": "2015-11-23T10:10:09.197Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
-            "updatedAt": "2015-11-18T12:21:01.357Z",
+            "updatedAt": "2015-11-23T10:10:09.197Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:01 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:08 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/2cMU9UUngYMqAEmw4Cm8Iw/files/en-US/process
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/2cMU9UUngYMqAEmw4Cm8Iw/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
@@ -463,17 +465,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:02 GMT
+      - Mon, 23 Nov 2015 10:10:13 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -481,7 +483,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2ESKF84OSoGqKYK6O0US0c
+      - content-api:3q2P6UGYekEya2mmCSKko2
       X-Powered-By:
       - Express
       Connection:
@@ -490,10 +492,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:02 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:11 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/2cMU9UUngYMqAEmw4Cm8Iw
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/2cMU9UUngYMqAEmw4Cm8Iw
     body:
       encoding: US-ASCII
       string: ''
@@ -520,19 +522,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:03 GMT
+      - Mon, 23 Nov 2015 10:10:13 GMT
       Etag:
-      - '"e07806405f2fd5238390c11aa700c030"'
+      - '"89f9057f37ea7bd0bc77db7a03d22b32"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -540,7 +542,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1g5Dig9q3C02YQcg4W2eKK
+      - content-api:3JQ6kbp7BC2yGUiSWA4EWo
       X-Powered-By:
       - Express
       Content-Length:
@@ -569,44 +571,44 @@ http_interactions:
                   },
                   "size": 26898
                 },
-                "url": "//images.contentful.com/wbtalxpseprz/2cMU9UUngYMqAEmw4Cm8Iw/4bb979950d59edeed3c09c172bfdfa63/Screen_Shot_2015-11-18_at_11.42.12.jpg"
+                "url": "//images.contentful.com/8rbh6yfkme6s/2cMU9UUngYMqAEmw4Cm8Iw/5a7c40665159f117a7e168cbffdb337f/Screen_Shot_2015-11-18_at_11.42.12.jpg"
               }
             }
           },
           "sys": {
             "id": "2cMU9UUngYMqAEmw4Cm8Iw",
             "type": "Asset",
-            "createdAt": "2015-11-18T12:21:01.356Z",
+            "createdAt": "2015-11-23T10:10:09.197Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T12:21:02.759Z",
+            "updatedAt": "2015-11-23T10:10:13.405Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:03 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:12 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/2cMU9UUngYMqAEmw4Cm8Iw/published
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/2cMU9UUngYMqAEmw4Cm8Iw/published
     body:
       encoding: US-ASCII
       string: ''
@@ -635,19 +637,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:04 GMT
+      - Mon, 23 Nov 2015 10:10:14 GMT
       Etag:
-      - '"649d59b2976af140bfb38b69533a414b"'
+      - '"cf3b56114016cbb2b1738d8b115e1bfb"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -655,7 +657,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6xs5pPPJe0I8mOSuMCuSOQ
+      - content-api:5QQUBeRaxyYi6WGQU4OGou
       X-Powered-By:
       - Express
       Content-Length:
@@ -684,55 +686,55 @@ http_interactions:
                   },
                   "size": 26898
                 },
-                "url": "//images.contentful.com/wbtalxpseprz/2cMU9UUngYMqAEmw4Cm8Iw/4bb979950d59edeed3c09c172bfdfa63/Screen_Shot_2015-11-18_at_11.42.12.jpg"
+                "url": "//images.contentful.com/8rbh6yfkme6s/2cMU9UUngYMqAEmw4Cm8Iw/5a7c40665159f117a7e168cbffdb337f/Screen_Shot_2015-11-18_at_11.42.12.jpg"
               }
             }
           },
           "sys": {
             "id": "2cMU9UUngYMqAEmw4Cm8Iw",
             "type": "Asset",
-            "createdAt": "2015-11-18T12:21:01.356Z",
+            "createdAt": "2015-11-23T10:10:09.197Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T12:21:04.269Z",
+            "updatedAt": "2015-11-23T10:10:14.222Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T12:21:04.269Z",
+            "firstPublishedAt": "2015-11-23T10:10:14.222Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T12:21:04.269Z",
+            "publishedAt": "2015-11-23T10:10:14.222Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:04 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:13 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/4D5sv49qaAoMIkWgAW8g0I
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/4D5sv49qaAoMIkWgAW8g0I
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Screen Shot 2015-11-16 at 21.37.19"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"Screen
@@ -758,19 +760,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:06 GMT
+      - Mon, 23 Nov 2015 10:10:15 GMT
       Etag:
-      - '"f364a5162e6f93e571dd8da2df2f118c"'
+      - '"9f0867dee1111360d4662a94c5f166cb"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -778,7 +780,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5pdHNfaEggkAEOwEcO2GgA
+      - content-api:4G8370Etlm4uCIAkAqkwIK
       X-Powered-By:
       - Express
       Content-Length:
@@ -808,36 +810,36 @@ http_interactions:
             "id": "4D5sv49qaAoMIkWgAW8g0I",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T12:21:05.965Z",
+            "createdAt": "2015-11-23T10:10:15.168Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
-            "updatedAt": "2015-11-18T12:21:05.965Z",
+            "updatedAt": "2015-11-23T10:10:15.168Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:05 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:14 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/4D5sv49qaAoMIkWgAW8g0I/files/en-US/process
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/4D5sv49qaAoMIkWgAW8g0I/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
@@ -866,17 +868,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:06 GMT
+      - Mon, 23 Nov 2015 10:10:15 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -884,7 +886,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4WCAYOc0nCKMQ24G0GKgO2
+      - content-api:31uKewjlF6CwM8UOKegEyI
       X-Powered-By:
       - Express
       Connection:
@@ -893,10 +895,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:06 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:14 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/4D5sv49qaAoMIkWgAW8g0I
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/4D5sv49qaAoMIkWgAW8g0I
     body:
       encoding: US-ASCII
       string: ''
@@ -923,19 +925,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:07 GMT
+      - Mon, 23 Nov 2015 10:10:16 GMT
       Etag:
-      - '"bfdf175e681d6d2071273686da06994d"'
+      - '"c05e146c2d3fbf2532f154fd36c879b2"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -943,7 +945,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3FhGUPG8YUWqsWGWqe8CAM
+      - content-api:1s9owZS8fGo2wue8i66OqM
       X-Powered-By:
       - Express
       Content-Length:
@@ -972,44 +974,44 @@ http_interactions:
                   },
                   "size": 25892
                 },
-                "url": "//images.contentful.com/wbtalxpseprz/4D5sv49qaAoMIkWgAW8g0I/6603b3ac321b0fad9157232eb1dda83a/Screen_Shot_2015-11-16_at_21.37.19.jpg"
+                "url": "//images.contentful.com/8rbh6yfkme6s/4D5sv49qaAoMIkWgAW8g0I/67c4fe5218effc75ed26c2e91080a25e/Screen_Shot_2015-11-16_at_21.37.19.jpg"
               }
             }
           },
           "sys": {
             "id": "4D5sv49qaAoMIkWgAW8g0I",
             "type": "Asset",
-            "createdAt": "2015-11-18T12:21:05.965Z",
+            "createdAt": "2015-11-23T10:10:15.168Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T12:21:07.151Z",
+            "updatedAt": "2015-11-23T10:10:16.170Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:07 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:15 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/4D5sv49qaAoMIkWgAW8g0I/published
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/4D5sv49qaAoMIkWgAW8g0I/published
     body:
       encoding: US-ASCII
       string: ''
@@ -1038,19 +1040,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:08 GMT
+      - Mon, 23 Nov 2015 10:10:17 GMT
       Etag:
-      - '"99285c5f45517e53a7020ad9995be04a"'
+      - '"308f630847e49fe38943e993a20a9453"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1058,7 +1060,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:ATBStKC3bUq4oEquogIoi
+      - content-api:5sgNi3DzMsO68seW0I20As
       X-Powered-By:
       - Express
       Content-Length:
@@ -1087,55 +1089,55 @@ http_interactions:
                   },
                   "size": 25892
                 },
-                "url": "//images.contentful.com/wbtalxpseprz/4D5sv49qaAoMIkWgAW8g0I/6603b3ac321b0fad9157232eb1dda83a/Screen_Shot_2015-11-16_at_21.37.19.jpg"
+                "url": "//images.contentful.com/8rbh6yfkme6s/4D5sv49qaAoMIkWgAW8g0I/67c4fe5218effc75ed26c2e91080a25e/Screen_Shot_2015-11-16_at_21.37.19.jpg"
               }
             }
           },
           "sys": {
             "id": "4D5sv49qaAoMIkWgAW8g0I",
             "type": "Asset",
-            "createdAt": "2015-11-18T12:21:05.965Z",
+            "createdAt": "2015-11-23T10:10:15.168Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T12:21:08.316Z",
+            "updatedAt": "2015-11-23T10:10:16.981Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T12:21:08.316Z",
+            "firstPublishedAt": "2015-11-23T10:10:16.981Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T12:21:08.316Z",
+            "publishedAt": "2015-11-23T10:10:16.981Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:08 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:15 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/4eX9aQsDdeqweg6Si00KaW
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/4eX9aQsDdeqweg6Si00KaW
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Screen Shot 2015-11-17 at 17.57.00"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"Screen
@@ -1161,19 +1163,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:09 GMT
+      - Mon, 23 Nov 2015 10:10:18 GMT
       Etag:
-      - '"c3256898469aa4a9b9a92b3a6201d1ce"'
+      - '"fc8ec18525e766c9f493b902f0f1ceef"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1181,7 +1183,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5QJDxLkENi08CQOS2ICUqU
+      - content-api:6zfuFndhQsYEIQiK8GKI4m
       X-Powered-By:
       - Express
       Content-Length:
@@ -1211,36 +1213,36 @@ http_interactions:
             "id": "4eX9aQsDdeqweg6Si00KaW",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T12:21:09.505Z",
+            "createdAt": "2015-11-23T10:10:17.946Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
-            "updatedAt": "2015-11-18T12:21:09.505Z",
+            "updatedAt": "2015-11-23T10:10:17.946Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:09 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:16 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/4eX9aQsDdeqweg6Si00KaW/files/en-US/process
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/4eX9aQsDdeqweg6Si00KaW/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
@@ -1269,17 +1271,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:10 GMT
+      - Mon, 23 Nov 2015 10:10:18 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1287,7 +1289,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1ZUwX1xFaI6cK6wIQIEMS2
+      - content-api:1pteq4LQOswkiomY26WMOi
       X-Powered-By:
       - Express
       Connection:
@@ -1296,10 +1298,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:10 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:17 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/4eX9aQsDdeqweg6Si00KaW
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/4eX9aQsDdeqweg6Si00KaW
     body:
       encoding: US-ASCII
       string: ''
@@ -1326,19 +1328,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:11 GMT
+      - Mon, 23 Nov 2015 10:10:19 GMT
       Etag:
-      - '"b709993a6404aff7aac5a873f13a1ec7"'
+      - '"e776860581080b8bf43200133cf65360"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1346,7 +1348,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3flF6dvEqQKGu2uMy2i0sG
+      - content-api:1Cdh0QfJGgKKSgOkOysECW
       X-Powered-By:
       - Express
       Content-Length:
@@ -1375,44 +1377,44 @@ http_interactions:
                   },
                   "size": 100009
                 },
-                "url": "//images.contentful.com/wbtalxpseprz/4eX9aQsDdeqweg6Si00KaW/54df28c9ff91b91228671d3f586c9661/Screen_Shot_2015-11-17_at_17.57.00.jpg"
+                "url": "//images.contentful.com/8rbh6yfkme6s/4eX9aQsDdeqweg6Si00KaW/12f130ad0afe8f72c59c890deaf41212/Screen_Shot_2015-11-17_at_17.57.00.jpg"
               }
             }
           },
           "sys": {
             "id": "4eX9aQsDdeqweg6Si00KaW",
             "type": "Asset",
-            "createdAt": "2015-11-18T12:21:09.505Z",
+            "createdAt": "2015-11-23T10:10:17.946Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T12:21:10.682Z",
+            "updatedAt": "2015-11-23T10:10:18.937Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:10 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:18 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/4eX9aQsDdeqweg6Si00KaW/published
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/4eX9aQsDdeqweg6Si00KaW/published
     body:
       encoding: US-ASCII
       string: ''
@@ -1441,19 +1443,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:11 GMT
+      - Mon, 23 Nov 2015 10:10:19 GMT
       Etag:
-      - '"36fd4b45c8bd4b99a7f62879c7da6bdf"'
+      - '"7fb49fc4b6e6be6b0fef09a34f69964f"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1461,7 +1463,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6w86nSvmCcUmkgoU4eOeOS
+      - content-api:1nQMIDRg24gCwwccGCKgGq
       X-Powered-By:
       - Express
       Content-Length:
@@ -1490,55 +1492,55 @@ http_interactions:
                   },
                   "size": 100009
                 },
-                "url": "//images.contentful.com/wbtalxpseprz/4eX9aQsDdeqweg6Si00KaW/54df28c9ff91b91228671d3f586c9661/Screen_Shot_2015-11-17_at_17.57.00.jpg"
+                "url": "//images.contentful.com/8rbh6yfkme6s/4eX9aQsDdeqweg6Si00KaW/12f130ad0afe8f72c59c890deaf41212/Screen_Shot_2015-11-17_at_17.57.00.jpg"
               }
             }
           },
           "sys": {
             "id": "4eX9aQsDdeqweg6Si00KaW",
             "type": "Asset",
-            "createdAt": "2015-11-18T12:21:09.505Z",
+            "createdAt": "2015-11-23T10:10:17.946Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T12:21:11.801Z",
+            "updatedAt": "2015-11-23T10:10:19.797Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T12:21:11.801Z",
+            "firstPublishedAt": "2015-11-23T10:10:19.797Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T12:21:11.801Z",
+            "publishedAt": "2015-11-23T10:10:19.797Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:11 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:18 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/7i1Ck3BG4o4KeIEUGosEeU
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/7i1Ck3BG4o4KeIEUGosEeU
     body:
       encoding: UTF-8
       string: '{"fields":{"title":{"en-US":"Screen Shot 2015-11-17 at 18.04.02"},"description":{"en-US":null},"file":{"en-US":{"contentType":"image/jpeg","fileName":"Screen
@@ -1564,19 +1566,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:12 GMT
+      - Mon, 23 Nov 2015 10:10:20 GMT
       Etag:
-      - '"d5c3282578dd8185d2e5f9d3d94be17b"'
+      - '"4d963e9d44420608419dd4d701bba6cc"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1584,7 +1586,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:7rjZoKREYMkwEwGwIcgCwy
+      - content-api:1SZ7smwZzeUySumOO8AwSk
       X-Powered-By:
       - Express
       Content-Length:
@@ -1614,36 +1616,36 @@ http_interactions:
             "id": "7i1Ck3BG4o4KeIEUGosEeU",
             "type": "Asset",
             "version": 1,
-            "createdAt": "2015-11-18T12:21:12.916Z",
+            "createdAt": "2015-11-23T10:10:20.794Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
-            "updatedAt": "2015-11-18T12:21:12.916Z",
+            "updatedAt": "2015-11-23T10:10:20.794Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:12 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:19 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/7i1Ck3BG4o4KeIEUGosEeU/files/en-US/process
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/7i1Ck3BG4o4KeIEUGosEeU/files/en-US/process
     body:
       encoding: US-ASCII
       string: ''
@@ -1672,17 +1674,17 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:13 GMT
+      - Mon, 23 Nov 2015 10:10:21 GMT
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1690,7 +1692,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6oUz5t92tUqK6OWG8sgu2u
+      - content-api:vfXKReF7xI0oO2coGOME8
       X-Powered-By:
       - Express
       Connection:
@@ -1699,10 +1701,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:13 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:20 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/7i1Ck3BG4o4KeIEUGosEeU
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/7i1Ck3BG4o4KeIEUGosEeU
     body:
       encoding: US-ASCII
       string: ''
@@ -1729,19 +1731,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:14 GMT
+      - Mon, 23 Nov 2015 10:10:22 GMT
       Etag:
-      - '"59cc7a8f02acb240a61f3b9275c9428a"'
+      - '"8d129d81688292fbb42e859fb2c4526c"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1749,7 +1751,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:4KPYijcOXKAKaKe6Qo44wS
+      - content-api:4D743gx8VGyk204KgeImmG
       X-Powered-By:
       - Express
       Content-Length:
@@ -1778,44 +1780,44 @@ http_interactions:
                   },
                   "size": 29117
                 },
-                "url": "//images.contentful.com/wbtalxpseprz/7i1Ck3BG4o4KeIEUGosEeU/edf61ed5b73101bd90b57ced8d55f3fe/Screen_Shot_2015-11-17_at_18.04.02.jpg"
+                "url": "//images.contentful.com/8rbh6yfkme6s/7i1Ck3BG4o4KeIEUGosEeU/5276d4eb7decc09b3f78f391c0176409/Screen_Shot_2015-11-17_at_18.04.02.jpg"
               }
             }
           },
           "sys": {
             "id": "7i1Ck3BG4o4KeIEUGosEeU",
             "type": "Asset",
-            "createdAt": "2015-11-18T12:21:12.916Z",
+            "createdAt": "2015-11-23T10:10:20.794Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-18T12:21:13.922Z",
+            "updatedAt": "2015-11-23T10:10:22.079Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:14 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:21 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/assets/7i1Ck3BG4o4KeIEUGosEeU/published
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/assets/7i1Ck3BG4o4KeIEUGosEeU/published
     body:
       encoding: US-ASCII
       string: ''
@@ -1844,19 +1846,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:15 GMT
+      - Mon, 23 Nov 2015 10:10:23 GMT
       Etag:
-      - '"1de24f2bcfb2889577ff0f7f06777e4c"'
+      - '"2d83fe1e68e7ffc13dbd3b6d4b0bf52a"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1864,7 +1866,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:I8BTW33dqCGQ6uoA8SowU
+      - content-api:1LLsfSnJRCK0aWaQSeyEWG
       X-Powered-By:
       - Express
       Content-Length:
@@ -1893,55 +1895,55 @@ http_interactions:
                   },
                   "size": 29117
                 },
-                "url": "//images.contentful.com/wbtalxpseprz/7i1Ck3BG4o4KeIEUGosEeU/edf61ed5b73101bd90b57ced8d55f3fe/Screen_Shot_2015-11-17_at_18.04.02.jpg"
+                "url": "//images.contentful.com/8rbh6yfkme6s/7i1Ck3BG4o4KeIEUGosEeU/5276d4eb7decc09b3f78f391c0176409/Screen_Shot_2015-11-17_at_18.04.02.jpg"
               }
             }
           },
           "sys": {
             "id": "7i1Ck3BG4o4KeIEUGosEeU",
             "type": "Asset",
-            "createdAt": "2015-11-18T12:21:12.916Z",
+            "createdAt": "2015-11-23T10:10:20.794Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "version": 3,
-            "updatedAt": "2015-11-18T12:21:15.092Z",
+            "updatedAt": "2015-11-23T10:10:22.937Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-18T12:21:15.092Z",
+            "firstPublishedAt": "2015-11-23T10:10:22.937Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T12:21:15.092Z",
+            "publishedAt": "2015-11-23T10:10:22.937Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 2
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:15 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:21 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/content_types/1VX60jHERm6yuem8I2agWG
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/content_types/1VX60jHERm6yuem8I2agWG
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,19 +1970,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:16 GMT
+      - Mon, 23 Nov 2015 10:10:23 GMT
       Etag:
-      - '"7b9e77838b44b2ddd633213deca22570"'
+      - '"e207c5c1bfcca906d3308228de189d54"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1988,7 +1990,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:A6yNKMcrYGuSEGqScI0o0
+      - content-api:5Ct5vQzEROqe60QYuaac8Q
       X-Powered-By:
       - Express
       Content-Length:
@@ -2025,51 +2027,51 @@ http_interactions:
           "sys": {
             "id": "1VX60jHERm6yuem8I2agWG",
             "type": "ContentType",
-            "createdAt": "2015-11-18T12:20:59.205Z",
+            "createdAt": "2015-11-23T10:10:04.310Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
-            "firstPublishedAt": "2015-11-18T12:21:00.054Z",
+            "firstPublishedAt": "2015-11-23T10:10:08.012Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-18T12:21:00.054Z",
+            "publishedAt": "2015-11-23T10:10:08.012Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-18T12:21:00.113Z",
+            "updatedAt": "2015-11-23T10:10:08.063Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:15 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:22 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/entries/5nQB3z8RgW8CUG6uGyCsEw
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/entries/5nQB3z8RgW8CUG6uGyCsEw
     body:
       encoding: UTF-8
-      string: '{"fields":{"assets":{"en-US":[{"sys":{"type":"Link","linkType":"Asset","id":"4eX9aQsDdeqweg6Si00KaW"}},{"sys":{"type":"Link","linkType":"Asset","id":"4D5sv49qaAoMIkWgAW8g0I"}}]},"title":{"en-US":"yolo"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
       - RubyContentfulManagementGem/0.7.2
@@ -2093,19 +2095,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:17 GMT
+      - Mon, 23 Nov 2015 10:10:24 GMT
       Etag:
-      - '"6d7ec481beda38c7bfc32570c63e9db0"'
+      - '"07635fdd57792ffbcee758d5f7e4aa4a"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2113,57 +2115,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:jaQkvgGwCWCMUKsykaqUI
+      - content-api:4uATW5p6Pe8AuOqOEWa22M
       X-Powered-By:
       - Express
       Content-Length:
-      - '1160'
+      - '755'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "assets": {
-              "en-US": [
-                {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Asset",
-                    "id": "4eX9aQsDdeqweg6Si00KaW"
-                  }
-                },
-                {
-                  "sys": {
-                    "type": "Link",
-                    "linkType": "Asset",
-                    "id": "4D5sv49qaAoMIkWgAW8g0I"
-                  }
-                }
-              ]
-            },
-            "title": {
-              "en-US": "yolo"
-            }
-          },
+          "fields": {},
           "sys": {
             "id": "5nQB3z8RgW8CUG6uGyCsEw",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-18T12:21:17.121Z",
+            "createdAt": "2015-11-23T10:10:24.528Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "contentType": {
@@ -2173,24 +2153,24 @@ http_interactions:
                 "id": "1VX60jHERm6yuem8I2agWG"
               }
             },
-            "updatedAt": "2015-11-18T12:21:17.121Z",
+            "updatedAt": "2015-11-23T10:10:24.528Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:17 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:23 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/entries/5nQB3z8RgW8CUG6uGyCsEw
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/entries/5nQB3z8RgW8CUG6uGyCsEw
     body:
       encoding: UTF-8
-      string: '{"fields":{"assets":{"en-US":[{"sys":{"type":"Link","linkType":"Asset","id":"4eX9aQsDdeqweg6Si00KaW"}},{"sys":{"type":"Link","linkType":"Asset","id":"4D5sv49qaAoMIkWgAW8g0I"}}]},"title":{"en-US":"yolo"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
       - RubyContentfulManagementGem/0.7.2
@@ -2214,19 +2194,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:18 GMT
+      - Mon, 23 Nov 2015 10:10:25 GMT
       Etag:
-      - '"1c4cb06a074094cc19dbf3a639160e0e"'
+      - '"daf0d168ea1a7665d4539d5d65df27bc"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2234,7 +2214,205 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:aGO8CEN07QYO22ic4cOY8
+      - content-api:6EIVthXSggUoc2oC84IAWU
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '755'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "5nQB3z8RgW8CUG6uGyCsEw",
+            "type": "Entry",
+            "createdAt": "2015-11-23T10:10:24.528Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "8rbh6yfkme6s"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "1VX60jHERm6yuem8I2agWG"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-23T10:10:25.377Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 23 Nov 2015 10:10:24 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/entries/5nQB3z8RgW8CUG6uGyCsEw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.2
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - 8rbh6yfkme6s
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 23 Nov 2015 10:10:26 GMT
+      Etag:
+      - '"13a5f50854a98fa440ade4a6422d4a8a"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:1ozBBFLEcUK0yqw20IuY8I
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '755'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "5nQB3z8RgW8CUG6uGyCsEw",
+            "type": "Entry",
+            "createdAt": "2015-11-23T10:10:24.528Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "8rbh6yfkme6s"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "1VX60jHERm6yuem8I2agWG"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-11-23T10:10:25.427Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 23 Nov 2015 10:10:24 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/entries/5nQB3z8RgW8CUG6uGyCsEw
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"assets":{"en-US":[{"sys":{"type":"Link","linkType":"Asset","id":"4eX9aQsDdeqweg6Si00KaW"}},{"sys":{"type":"Link","linkType":"Asset","id":"4D5sv49qaAoMIkWgAW8g0I"}}]},"title":{"en-US":"yolo"}}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.2
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - 8rbh6yfkme6s
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 23 Nov 2015 10:10:26 GMT
+      Etag:
+      - '"61958ebb5453449ff9d965bf906b128a"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:KvQZgmsh8cYkYyuMIYe2I
       X-Powered-By:
       - Express
       Content-Length:
@@ -2271,19 +2449,19 @@ http_interactions:
           "sys": {
             "id": "5nQB3z8RgW8CUG6uGyCsEw",
             "type": "Entry",
-            "createdAt": "2015-11-18T12:21:17.121Z",
+            "createdAt": "2015-11-23T10:10:24.528Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "wbtalxpseprz"
+                "id": "8rbh6yfkme6s"
               }
             },
             "contentType": {
@@ -2293,25 +2471,25 @@ http_interactions:
                 "id": "1VX60jHERm6yuem8I2agWG"
               }
             },
-            "version": 2,
-            "updatedAt": "2015-11-18T12:21:18.227Z",
+            "version": 3,
+            "updatedAt": "2015-11-23T10:10:26.873Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:18 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:25 GMT
 - request:
-    method: get
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/entries?content_type=1VX60jHERm6yuem8I2agWG
+    method: put
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/entries/5nQB3z8RgW8CUG6uGyCsEw
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"fields":{"assets":{"en-US":[{"sys":{"type":"Link","linkType":"Asset","id":"4eX9aQsDdeqweg6Si00KaW"}},{"sys":{"type":"Link","linkType":"Asset","id":"4D5sv49qaAoMIkWgAW8g0I"}}]},"title":{"en-US":"yolo"}}}'
     headers:
       User-Agent:
       - RubyContentfulManagementGem/0.7.2
@@ -2319,6 +2497,8 @@ http_interactions:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
       Connection:
       - close
       Host:
@@ -2333,19 +2513,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - wbtalxpseprz
+      - 8rbh6yfkme6s
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:18 GMT
+      - Mon, 23 Nov 2015 10:10:27 GMT
       Etag:
-      - '"29f2c21be26360c424f617d8592cf6f9"'
+      - '"d9c4e17783a748e58cd1113cc5895667"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2353,34 +2533,461 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:6uMOvUaWm4wAY882giAASk
+      - content-api:7ibBz1ABUsoQAGiW0Y8o6c
       X-Powered-By:
       - Express
       Content-Length:
-      - '97'
+      - '1160'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "sys": {
-            "type": "Array"
+          "fields": {
+            "assets": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Asset",
+                    "id": "4eX9aQsDdeqweg6Si00KaW"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Asset",
+                    "id": "4D5sv49qaAoMIkWgAW8g0I"
+                  }
+                }
+              ]
+            },
+            "title": {
+              "en-US": "yolo"
+            }
           },
-          "total": 0,
-          "skip": 0,
-          "limit": 100,
-          "items": []
+          "sys": {
+            "id": "5nQB3z8RgW8CUG6uGyCsEw",
+            "type": "Entry",
+            "createdAt": "2015-11-23T10:10:24.528Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "8rbh6yfkme6s"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "1VX60jHERm6yuem8I2agWG"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-23T10:10:27.748Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
         }
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:18 GMT
+  recorded_at: Mon, 23 Nov 2015 10:10:26 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/entries/5nQB3z8RgW8CUG6uGyCsEw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.2
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - 8rbh6yfkme6s
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 23 Nov 2015 10:10:28 GMT
+      Etag:
+      - '"6a28b9cbb1bb99efeee2bc9d4825a846"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3vpes7DtMkYOqm28O2ocQQ
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1160'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "assets": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Asset",
+                    "id": "4eX9aQsDdeqweg6Si00KaW"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Asset",
+                    "id": "4D5sv49qaAoMIkWgAW8g0I"
+                  }
+                }
+              ]
+            },
+            "title": {
+              "en-US": "yolo"
+            }
+          },
+          "sys": {
+            "id": "5nQB3z8RgW8CUG6uGyCsEw",
+            "type": "Entry",
+            "createdAt": "2015-11-23T10:10:24.528Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "8rbh6yfkme6s"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "1VX60jHERm6yuem8I2agWG"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-23T10:10:27.801Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 23 Nov 2015 10:10:27 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/entries/5nQB3z8RgW8CUG6uGyCsEw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.2
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - 8rbh6yfkme6s
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 23 Nov 2015 10:10:28 GMT
+      Etag:
+      - '"6a28b9cbb1bb99efeee2bc9d4825a846"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:4zTLo1WRwQkoG02KCaeWqM
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1160'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "assets": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Asset",
+                    "id": "4eX9aQsDdeqweg6Si00KaW"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Asset",
+                    "id": "4D5sv49qaAoMIkWgAW8g0I"
+                  }
+                }
+              ]
+            },
+            "title": {
+              "en-US": "yolo"
+            }
+          },
+          "sys": {
+            "id": "5nQB3z8RgW8CUG6uGyCsEw",
+            "type": "Entry",
+            "createdAt": "2015-11-23T10:10:24.528Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "8rbh6yfkme6s"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "1VX60jHERm6yuem8I2agWG"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-11-23T10:10:27.801Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 23 Nov 2015 10:10:27 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/entries/5nQB3z8RgW8CUG6uGyCsEw/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.2
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - 8rbh6yfkme6s
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 23 Nov 2015 10:10:29 GMT
+      Etag:
+      - '"ee01ecf6dbd3243452ee4ddbb737214d"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:mtJFKSrJIsgSgoWMkSoii
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1455'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "assets": {
+              "en-US": [
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Asset",
+                    "id": "4eX9aQsDdeqweg6Si00KaW"
+                  }
+                },
+                {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Asset",
+                    "id": "4D5sv49qaAoMIkWgAW8g0I"
+                  }
+                }
+              ]
+            },
+            "title": {
+              "en-US": "yolo"
+            }
+          },
+          "sys": {
+            "id": "5nQB3z8RgW8CUG6uGyCsEw",
+            "type": "Entry",
+            "createdAt": "2015-11-23T10:10:24.528Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "8rbh6yfkme6s"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "1VX60jHERm6yuem8I2agWG"
+              }
+            },
+            "version": 5,
+            "updatedAt": "2015-11-23T10:10:29.790Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "firstPublishedAt": "2015-11-23T10:10:29.790Z",
+            "publishedCounter": 1,
+            "publishedAt": "2015-11-23T10:10:29.790Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "publishedVersion": 4
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 23 Nov 2015 10:10:28 GMT
 - request:
     method: post
-    uri: https://api.contentful.com/spaces/wbtalxpseprz/api_keys
+    uri: https://api.contentful.com/spaces/8rbh6yfkme6s/api_keys
     body:
       encoding: UTF-8
       string: '{"name":"Bootstrap Token","description":"Created with ''contentful_bootstrap.rb
-        v2.0.1''"}'
+        v2.0.2''"}'
     headers:
       User-Agent:
       - RubyContentfulManagementGem/0.7.2
@@ -2404,7 +3011,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -2414,11 +3021,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Wed, 18 Nov 2015 12:21:20 GMT
+      - Mon, 23 Nov 2015 10:10:30 GMT
       Etag:
-      - '"f611b1857201b4d2eb91ac8260090f46"'
+      - '"97c3cc3512304da39feefd26d65a17f9"'
       Location:
-      - https://api.contentful.com/spaces/wbtalxpseprz/api_keys/6dfG2Xl6BXeVXvuInpnqIY
+      - https://api.contentful.com/spaces/8rbh6yfkme6s/api_keys/2JjugsfSBi7SM9Ne03UwXa
       Server:
       - nginx
       Status:
@@ -2428,7 +3035,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - b89-1468408790
+      - b89-1471620153
       Content-Length:
       - '954'
       Connection:
@@ -2439,35 +3046,35 @@ http_interactions:
         {
           "sys":{
             "type":"ApiKey",
-            "id":"6dfG2Xl6BXeVXvuInpnqIY",
+            "id":"2JjugsfSBi7SM9Ne03UwXa",
             "version":0,
             "space":{
               "sys":{
                 "type":"Link",
                 "linkType":"Space",
-                "id":"wbtalxpseprz"
+                "id":"8rbh6yfkme6s"
               }
             },
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-18T12:21:19Z",
+            "createdAt":"2015-11-23T10:10:30Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-18T12:21:19Z"
+            "updatedAt":"2015-11-23T10:10:30Z"
           },
           "name":"Bootstrap Token",
-          "description":"Created with 'contentful_bootstrap.rb v2.0.1'",
-          "accessToken":"d65077d23de1bb749e4deb1976bbc1fea5b0008c622ec3d278f8ab7aa123eded",
+          "description":"Created with 'contentful_bootstrap.rb v2.0.2'",
+          "accessToken":"031b8e15ed7351bc0dac2b2612fb72e1d54b1f878c87b485f8642fe1b57db9e4",
           "policies":[
             {
               "effect":"allow",
@@ -2478,11 +3085,11 @@ http_interactions:
             "sys":{
               "type":"Link",
               "linkType":"PreviewApiKey",
-              "id":"6dgPrUi9iZhcELD9vLr3Ks"
+              "id":"2JkFucBDyobwZkIX2BDXIo"
             }
           }
         }
 
     http_version: 
-  recorded_at: Wed, 18 Nov 2015 12:21:19 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Mon, 23 Nov 2015 10:10:29 GMT
+recorded_with: VCR 3.0.0

--- a/spec/fixtures/vcr_fixtures/no_ids.yml
+++ b/spec/fixtures/vcr_fixtures/no_ids.yml
@@ -8,15 +8,15 @@ http_interactions:
       string: '{"name":"no_ids_space","defaultLocale":"en-US"}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
+      X-Contentful-Organization:
+      - 1PLOOEmTI2S1NYald2TemO
       Connection:
       - close
-      Host:
-      - api.contentful.com
   response:
     status:
       code: 201
@@ -29,7 +29,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -39,11 +39,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Fri, 27 Nov 2015 12:07:40 GMT
+      - Mon, 21 Dec 2015 09:54:19 GMT
       Etag:
-      - '"b1a38b74b55807c72d38df27eca478ce"'
+      - '"d35e54cc518b3e78c8d5ef343960fca1"'
       Location:
-      - https://api.contentful.com/spaces/pla6gab6vcyi
+      - https://api.contentful.com/spaces/fbrhs5tvrf52
       Server:
       - nginx
       Status:
@@ -53,7 +53,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - 0b5-130656312
+      - 0b5-149627625
       Content-Length:
       - '455'
       Connection:
@@ -64,47 +64,45 @@ http_interactions:
         {
           "sys":{
             "type":"Space",
-            "id":"pla6gab6vcyi",
+            "id":"fbrhs5tvrf52",
             "version":1,
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-27T12:07:38Z",
+            "createdAt":"2015-12-21T09:54:18Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-27T12:07:38Z"
+            "updatedAt":"2015-12-21T09:54:18Z"
           },
           "name":"no_ids_space"
         }
 
     http_version: 
-  recorded_at: Fri, 27 Nov 2015 12:07:40 GMT
+  recorded_at: Mon, 21 Dec 2015 09:54:21 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/pla6gab6vcyi/content_types/cat
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/content_types/cat
     body:
       encoding: UTF-8
       string: '{"displayField":null,"name":"Cat","description":null,"fields":[{"id":"name","name":"Name","type":"Symbol"}]}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Connection:
       - close
-      Host:
-      - api.contentful.com
   response:
     status:
       code: 201
@@ -115,19 +113,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - pla6gab6vcyi
+      - fbrhs5tvrf52
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Fri, 27 Nov 2015 12:07:42 GMT
+      - Mon, 21 Dec 2015 09:54:23 GMT
       Etag:
-      - '"9c6d3e77ce5b283750c5171a34471ba6"'
+      - '"c5a3f0b9e8f7bc55a6d375d2c24c4182"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -135,7 +133,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2Pd4rLWS7CuSgCqUKO8S0a
+      - content-api:1BGdsY38Hi8OIKa0UUMgkk
       X-Powered-By:
       - Express
       Content-Length:
@@ -162,42 +160,42 @@ http_interactions:
             "id": "cat",
             "type": "ContentType",
             "version": 1,
-            "createdAt": "2015-11-27T12:07:42.028Z",
+            "createdAt": "2015-12-21T09:54:23.964Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "pla6gab6vcyi"
+                "id": "fbrhs5tvrf52"
               }
             },
-            "updatedAt": "2015-11-27T12:07:42.028Z",
+            "updatedAt": "2015-12-21T09:54:23.964Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Nov 2015 12:07:42 GMT
+  recorded_at: Mon, 21 Dec 2015 09:54:25 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/pla6gab6vcyi/content_types/cat/published
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/content_types/cat/published
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -208,8 +206,6 @@ http_interactions:
       - '0'
       Connection:
       - close
-      Host:
-      - api.contentful.com
   response:
     status:
       code: 200
@@ -220,19 +216,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - pla6gab6vcyi
+      - fbrhs5tvrf52
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Fri, 27 Nov 2015 12:07:43 GMT
+      - Mon, 21 Dec 2015 09:54:27 GMT
       Etag:
-      - '"bf137aa7623f998107065374efa5133a"'
+      - '"fb78c3d736efc6b74546195f304caacd"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -240,7 +236,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:1bdPLWEI9gqu6CA8U6KY8S
+      - content-api:5J72YK5zigyUO0iYSIaYei
       X-Powered-By:
       - Express
       Content-Length:
@@ -266,54 +262,54 @@ http_interactions:
           "sys": {
             "id": "cat",
             "type": "ContentType",
-            "createdAt": "2015-11-27T12:07:42.028Z",
+            "createdAt": "2015-12-21T09:54:23.964Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "pla6gab6vcyi"
+                "id": "fbrhs5tvrf52"
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-27T12:07:43.186Z",
+            "updatedAt": "2015-12-21T09:54:27.539Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "firstPublishedAt": "2015-11-27T12:07:43.186Z",
+            "firstPublishedAt": "2015-12-21T09:54:27.539Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-27T12:07:43.186Z",
+            "publishedAt": "2015-12-21T09:54:27.539Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Nov 2015 12:07:43 GMT
+  recorded_at: Mon, 21 Dec 2015 09:54:29 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/pla6gab6vcyi/content_types/cat
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/content_types/cat
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -322,8 +318,6 @@ http_interactions:
       - '0'
       Connection:
       - close
-      Host:
-      - api.contentful.com
   response:
     status:
       code: 200
@@ -334,19 +328,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - pla6gab6vcyi
+      - fbrhs5tvrf52
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Fri, 27 Nov 2015 12:07:44 GMT
+      - Mon, 21 Dec 2015 09:54:28 GMT
       Etag:
-      - '"fad9b7235c1dfb5a3674822ea8a7fe63"'
+      - '"b0e85ce0b9e003b3f6206aa619c8f969"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -354,7 +348,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:nqOYoUXR9mWCieQEymumO
+      - content-api:2kAU1l23GASoSG0sQqSs6W
       X-Powered-By:
       - Express
       Content-Length:
@@ -380,54 +374,54 @@ http_interactions:
           "sys": {
             "id": "cat",
             "type": "ContentType",
-            "createdAt": "2015-11-27T12:07:42.028Z",
+            "createdAt": "2015-12-21T09:54:23.964Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "pla6gab6vcyi"
+                "id": "fbrhs5tvrf52"
               }
             },
-            "firstPublishedAt": "2015-11-27T12:07:43.186Z",
+            "firstPublishedAt": "2015-12-21T09:54:27.539Z",
             "publishedCounter": 1,
-            "publishedAt": "2015-11-27T12:07:43.186Z",
+            "publishedAt": "2015-12-21T09:54:27.539Z",
             "publishedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "publishedVersion": 1,
             "version": 2,
-            "updatedAt": "2015-11-27T12:07:43.237Z",
+            "updatedAt": "2015-12-21T09:54:27.566Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Nov 2015 12:07:44 GMT
+  recorded_at: Mon, 21 Dec 2015 09:54:30 GMT
 - request:
     method: post
-    uri: https://api.contentful.com/spaces/pla6gab6vcyi/entries/
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/entries/
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Nyan Cat"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -436,8 +430,6 @@ http_interactions:
       - cat
       Connection:
       - close
-      Host:
-      - api.contentful.com
   response:
     status:
       code: 201
@@ -448,19 +440,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - pla6gab6vcyi
+      - fbrhs5tvrf52
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Fri, 27 Nov 2015 12:07:46 GMT
+      - Mon, 21 Dec 2015 09:54:29 GMT
       Etag:
-      - '"2cfdce8255537ca356b6c064e5c1ac07"'
+      - '"60b6bc6157feb4a5b104b1258584f1a6"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -468,39 +460,35 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:2qwLcjujpa6mus2UKAQwUq
+      - content-api:31Pr2fzfUQIGs48aomssKC
       X-Powered-By:
       - Express
       Content-Length:
-      - '785'
+      - '735'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Nyan Cat"
-            }
-          },
+          "fields": {},
           "sys": {
-            "id": "1FMnWeKEzm244yGAs0aSAu",
+            "id": "iIRoS058jK8g0E0C0ew2C",
             "type": "Entry",
             "version": 1,
-            "createdAt": "2015-11-27T12:07:46.029Z",
+            "createdAt": "2015-12-21T09:54:29.177Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "pla6gab6vcyi"
+                "id": "fbrhs5tvrf52"
               }
             },
             "contentType": {
@@ -510,27 +498,27 @@ http_interactions:
                 "id": "cat"
               }
             },
-            "updatedAt": "2015-11-27T12:07:46.029Z",
+            "updatedAt": "2015-12-21T09:54:29.177Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Nov 2015 12:07:46 GMT
+  recorded_at: Mon, 21 Dec 2015 09:54:30 GMT
 - request:
     method: put
-    uri: https://api.contentful.com/spaces/pla6gab6vcyi/entries/1FMnWeKEzm244yGAs0aSAu
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/entries/iIRoS058jK8g0E0C0ew2C
     body:
       encoding: UTF-8
-      string: '{"fields":{"name":{"en-US":"Nyan Cat"}}}'
+      string: '{"fields":{}}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
@@ -539,8 +527,6 @@ http_interactions:
       - '1'
       Connection:
       - close
-      Host:
-      - api.contentful.com
   response:
     status:
       code: 200
@@ -551,19 +537,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - pla6gab6vcyi
+      - fbrhs5tvrf52
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Fri, 27 Nov 2015 12:07:47 GMT
+      - Mon, 21 Dec 2015 09:54:29 GMT
       Etag:
-      - '"2fc8cdffe421a700569027c3d9803a49"'
+      - '"6d20995cd37efcbb83c3da71fb7a378f"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -571,38 +557,34 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:3nWnD1Mmp2Ii80QQCYisSG
+      - content-api:59pUpOiqJ24I6OiGe68coQ
       X-Powered-By:
       - Express
       Content-Length:
-      - '785'
+      - '735'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
-          "fields": {
-            "name": {
-              "en-US": "Nyan Cat"
-            }
-          },
+          "fields": {},
           "sys": {
-            "id": "1FMnWeKEzm244yGAs0aSAu",
+            "id": "iIRoS058jK8g0E0C0ew2C",
             "type": "Entry",
-            "createdAt": "2015-11-27T12:07:46.029Z",
+            "createdAt": "2015-12-21T09:54:29.177Z",
             "createdBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             },
             "space": {
               "sys": {
                 "type": "Link",
                 "linkType": "Space",
-                "id": "pla6gab6vcyi"
+                "id": "fbrhs5tvrf52"
               }
             },
             "contentType": {
@@ -613,35 +595,35 @@ http_interactions:
               }
             },
             "version": 2,
-            "updatedAt": "2015-11-27T12:07:47.333Z",
+            "updatedAt": "2015-12-21T09:54:29.963Z",
             "updatedBy": {
               "sys": {
                 "type": "Link",
                 "linkType": "User",
-                "id": "4SejVrWT96dvL9IV4Nb7sQ"
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
               }
             }
           }
         }
     http_version: 
-  recorded_at: Fri, 27 Nov 2015 12:07:47 GMT
+  recorded_at: Mon, 21 Dec 2015 09:54:31 GMT
 - request:
     method: get
-    uri: https://api.contentful.com/spaces/pla6gab6vcyi/entries?content_type=cat
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/entries/iIRoS058jK8g0E0C0ew2C
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
       Connection:
       - close
-      Host:
-      - api.contentful.com
   response:
     status:
       code: 200
@@ -652,19 +634,19 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
       - '1728000'
       Cf-Space-Id:
-      - pla6gab6vcyi
+      - fbrhs5tvrf52
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Fri, 27 Nov 2015 12:07:48 GMT
+      - Mon, 21 Dec 2015 09:54:34 GMT
       Etag:
-      - '"29f2c21be26360c424f617d8592cf6f9"'
+      - '"0db8d9db2409ce03ce7c9f40546f7362"'
       Server:
       - nginx
       Strict-Transport-Security:
@@ -672,45 +654,570 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - content-api:5tWoSacJDaG8ouai88C4GM
+      - content-api:1rkkrltOjq8we4kC4u2Saa
       X-Powered-By:
       - Express
       Content-Length:
-      - '97'
+      - '735'
       Connection:
       - Close
     body:
       encoding: UTF-8
       string: |
         {
+          "fields": {},
           "sys": {
-            "type": "Array"
-          },
-          "total": 0,
-          "skip": 0,
-          "limit": 100,
-          "items": []
+            "id": "iIRoS058jK8g0E0C0ew2C",
+            "type": "Entry",
+            "createdAt": "2015-12-21T09:54:29.177Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "fbrhs5tvrf52"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "cat"
+              }
+            },
+            "version": 2,
+            "updatedAt": "2015-12-21T09:54:29.978Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
         }
     http_version: 
-  recorded_at: Fri, 27 Nov 2015 12:07:48 GMT
+  recorded_at: Mon, 21 Dec 2015 09:54:35 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/entries/iIRoS058jK8g0E0C0ew2C
+    body:
+      encoding: UTF-8
+      string: '{"fields":{}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - fbrhs5tvrf52
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 21 Dec 2015 09:54:34 GMT
+      Etag:
+      - '"ff8ce5f951d218785d869c52f27177ba"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:2s8cKtZLcQ0yQ8eKA4Yw68
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '735'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "iIRoS058jK8g0E0C0ew2C",
+            "type": "Entry",
+            "createdAt": "2015-12-21T09:54:29.177Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "fbrhs5tvrf52"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "cat"
+              }
+            },
+            "version": 3,
+            "updatedAt": "2015-12-21T09:54:34.887Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 21 Dec 2015 09:54:36 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/entries/iIRoS058jK8g0E0C0ew2C
+    body:
+      encoding: UTF-8
+      string: '{"fields":{}}'
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '3'
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - fbrhs5tvrf52
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 21 Dec 2015 09:54:35 GMT
+      Etag:
+      - '"667d7ff509254fd02e1acc7266460919"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5wtQXXNW5U6e2e2CqyYqYK
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '735'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "iIRoS058jK8g0E0C0ew2C",
+            "type": "Entry",
+            "createdAt": "2015-12-21T09:54:29.177Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "fbrhs5tvrf52"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "cat"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-12-21T09:54:35.629Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 21 Dec 2015 09:54:37 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/entries/iIRoS058jK8g0E0C0ew2C
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - fbrhs5tvrf52
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 21 Dec 2015 09:54:36 GMT
+      Etag:
+      - '"5fc654cebe68be45cf4306a1e8d19d8e"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:5qoJiwuz282QeOSgiy6Gky
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '735'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "iIRoS058jK8g0E0C0ew2C",
+            "type": "Entry",
+            "createdAt": "2015-12-21T09:54:29.177Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "fbrhs5tvrf52"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "cat"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-12-21T09:54:35.636Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 21 Dec 2015 09:54:37 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/entries/iIRoS058jK8g0E0C0ew2C
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - fbrhs5tvrf52
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 21 Dec 2015 09:54:36 GMT
+      Etag:
+      - '"5fc654cebe68be45cf4306a1e8d19d8e"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:3uyZ5SMscgeaiOCsm4qKo4
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '735'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "iIRoS058jK8g0E0C0ew2C",
+            "type": "Entry",
+            "createdAt": "2015-12-21T09:54:29.177Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "fbrhs5tvrf52"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "cat"
+              }
+            },
+            "version": 4,
+            "updatedAt": "2015-12-21T09:54:35.636Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 21 Dec 2015 09:54:38 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/entries/iIRoS058jK8g0E0C0ew2C/published
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContentfulManagementGem/0.7.3
+      Authorization:
+      - Bearer foobar
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Content-Length:
+      - '0'
+      Connection:
+      - close
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - fbrhs5tvrf52
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Mon, 21 Dec 2015 09:54:37 GMT
+      Etag:
+      - '"45bd8a4d4b05c64749a6805079882d39"'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Request-Id:
+      - content-api:6H2C2XEnmME24USyMKMa2Q
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1030'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {},
+          "sys": {
+            "id": "iIRoS058jK8g0E0C0ew2C",
+            "type": "Entry",
+            "createdAt": "2015-12-21T09:54:29.177Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "fbrhs5tvrf52"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "cat"
+              }
+            },
+            "version": 5,
+            "updatedAt": "2015-12-21T09:54:37.413Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "firstPublishedAt": "2015-12-21T09:54:37.413Z",
+            "publishedCounter": 1,
+            "publishedAt": "2015-12-21T09:54:37.413Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "4FLrUHftHW3v2BLi9fzfjU"
+              }
+            },
+            "publishedVersion": 4
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 21 Dec 2015 09:54:39 GMT
 - request:
     method: post
-    uri: https://api.contentful.com/spaces/pla6gab6vcyi/api_keys
+    uri: https://api.contentful.com/spaces/fbrhs5tvrf52/api_keys
     body:
       encoding: UTF-8
       string: '{"name":"Bootstrap Token","description":"Created with ''contentful_bootstrap.rb
         v2.0.2''"}'
     headers:
       User-Agent:
-      - RubyContentfulManagementGem/0.7.2
+      - RubyContentfulManagementGem/0.7.3
       Authorization:
       - Bearer foobar
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Connection:
       - close
-      Host:
-      - api.contentful.com
   response:
     status:
       code: 201
@@ -723,7 +1230,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - DELETE,GET,HEAD,POST,PUT,OPTIONS
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Expose-Headers:
       - Etag
       Access-Control-Max-Age:
@@ -733,11 +1240,11 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       Date:
-      - Fri, 27 Nov 2015 12:07:49 GMT
+      - Mon, 21 Dec 2015 09:54:38 GMT
       Etag:
-      - '"67cf210f74ba3133a62d16baca1a6b18"'
+      - '"f18040497fabf2c0e6ff6abb25b1ad72"'
       Location:
-      - https://api.contentful.com/spaces/pla6gab6vcyi/api_keys/37WYI75chkBgQ2tE6UawII
+      - https://api.contentful.com/spaces/fbrhs5tvrf52/api_keys/60V12pES0cfX9qlGkzOsoM
       Server:
       - nginx
       Status:
@@ -747,7 +1254,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Contentful-Request-Id:
-      - b89-1474504646
+      - 0b5-149627774
       Content-Length:
       - '954'
       Connection:
@@ -758,35 +1265,35 @@ http_interactions:
         {
           "sys":{
             "type":"ApiKey",
-            "id":"37WYI75chkBgQ2tE6UawII",
+            "id":"60V12pES0cfX9qlGkzOsoM",
             "version":0,
             "space":{
               "sys":{
                 "type":"Link",
                 "linkType":"Space",
-                "id":"pla6gab6vcyi"
+                "id":"fbrhs5tvrf52"
               }
             },
             "createdBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "createdAt":"2015-11-27T12:07:49Z",
+            "createdAt":"2015-12-21T09:54:38Z",
             "updatedBy":{
               "sys":{
                 "type":"Link",
                 "linkType":"User",
-                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+                "id":"4FLrUHftHW3v2BLi9fzfjU"
               }
             },
-            "updatedAt":"2015-11-27T12:07:49Z"
+            "updatedAt":"2015-12-21T09:54:38Z"
           },
           "name":"Bootstrap Token",
           "description":"Created with 'contentful_bootstrap.rb v2.0.2'",
-          "accessToken":"57ef487e5b20df03c89a203a1d0608ed4ba529625b516ac41651a1d6badbaf22",
+          "accessToken":"61eeaaac93e18cb4f23c5b0108dea17999bafa87215b4020945b4dc0dd3d7fcc",
           "policies":[
             {
               "effect":"allow",
@@ -797,11 +1304,11 @@ http_interactions:
             "sys":{
               "type":"Link",
               "linkType":"PreviewApiKey",
-              "id":"37ZN3JlPTqZtPTxlwWtdre"
+              "id":"60WmXduCRM5y97RucLE6pW"
             }
           }
         }
 
     http_version: 
-  recorded_at: Fri, 27 Nov 2015 12:07:49 GMT
-recorded_with: VCR 2.9.3
+  recorded_at: Mon, 21 Dec 2015 09:54:40 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
This PR is supposed to make it unnecessary to structure the templates so that linked entries are ordered. In order to do that, we first create all entries, then fill them with content in a second phase.

Requires contentful/contentful-management.rb#72