### PR TITLE
Fix import of single links for JSON templates

### DIFF
--- a/lib/contentful/bootstrap/templates/json_template.rb
+++ b/lib/contentful/bootstrap/templates/json_template.rb
@@ -75,7 +75,7 @@ module Contentful
               end
 
               link_fields.each do |lf|
-                processed_entry[lf] = create_link(entry[lf])
+                processed_entry[lf] = create_link(entry['fields'][lf])
               end
 
               array_fields.each do |af|

--- a/lib/contentful/bootstrap/templates/links/base.rb
+++ b/lib/contentful/bootstrap/templates/links/base.rb
@@ -27,6 +27,11 @@ module Contentful
           def management_class
             fail 'must implement'
           end
+
+          def ==(other)
+            return false unless other.is_a? self.class
+            other.id == id
+          end
         end
       end
     end

--- a/spec/contentful/bootstrap/templates/json_template_spec.rb
+++ b/spec/contentful/bootstrap/templates/json_template_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Contentful::Bootstrap::Templates::JsonTemplate do
   let(:space) { Contentful::Management::Space.new }
   let(:path) { File.expand_path(File.join('spec', 'fixtures', 'json_fixtures', 'simple.json')) }
-  subject { Contentful::Bootstrap::Templates::JsonTemplate.new space, path }
+  subject { described_class.new space, path }
 
   describe 'instance methods' do
     it '#content_types' do
@@ -70,6 +70,21 @@ describe Contentful::Bootstrap::Templates::JsonTemplate do
 
     it 'accepts templates with correct version' do
       expect { described_class.new space, ok_version_path }.not_to raise_error
+    end
+  end
+
+  describe 'issues' do
+    let(:link_entry_path) { File.expand_path(File.join('spec', 'fixtures', 'json_fixtures', 'links.json')) }
+
+    it 'links are not properly getting processed - #33' do
+      subject = described_class.new space, link_entry_path
+
+      expect(subject.entries["cat"].first).to eq(
+        {
+          "id" => "foo",
+          "link" => Contentful::Bootstrap::Templates::Links::Entry.new('foobar')
+        }
+      )
     end
   end
 end

--- a/spec/contentful/bootstrap/templates/links/asset_spec.rb
+++ b/spec/contentful/bootstrap/templates/links/asset_spec.rb
@@ -19,5 +19,19 @@ describe Contentful::Bootstrap::Templates::Links::Asset do
     it '#management_class' do
       expect(subject.management_class).to eq Contentful::Management::Asset
     end
+
+    describe '#==' do
+      it 'false when different type' do
+        expect(subject == 2).to be_falsey
+      end
+
+      it 'false when different id' do
+        expect(subject == described_class.new('bar')).to be_falsey
+      end
+
+      it 'true when same id' do
+        expect(subject == described_class.new('foo')).to be_truthy
+      end
+    end
   end
 end

--- a/spec/contentful/bootstrap/templates/links/base_spec.rb
+++ b/spec/contentful/bootstrap/templates/links/base_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Contentful::Bootstrap::Templates::Links::Base do
-  subject { Contentful::Bootstrap::Templates::Links::Base.new 'foo' }
+  subject { described_class.new 'foo' }
 
   describe 'instance methods' do
     it '#link_type' do
@@ -19,6 +19,20 @@ describe Contentful::Bootstrap::Templates::Links::Base do
 
       it '#management_class' do
         expect { subject.management_class }.to raise_error "must implement"
+      end
+
+      describe '#==' do
+        it 'false when different type' do
+          expect(subject == 2).to be_falsey
+        end
+
+        it 'false when different id' do
+          expect(subject == described_class.new('bar')).to be_falsey
+        end
+
+        it 'true when same id' do
+          expect(subject == described_class.new('foo')).to be_truthy
+        end
       end
     end
   end

--- a/spec/contentful/bootstrap/templates/links/entry_spec.rb
+++ b/spec/contentful/bootstrap/templates/links/entry_spec.rb
@@ -19,5 +19,19 @@ describe Contentful::Bootstrap::Templates::Links::Entry do
     it '#management_class' do
       expect(subject.management_class).to eq Contentful::Management::Entry
     end
+
+    describe '#==' do
+      it 'false when different type' do
+        expect(subject == 2).to be_falsey
+      end
+
+      it 'false when different id' do
+        expect(subject == described_class.new('bar')).to be_falsey
+      end
+
+      it 'true when same id' do
+        expect(subject == described_class.new('foo')).to be_truthy
+      end
+    end
   end
 end

--- a/spec/fixtures/json_fixtures/links.json
+++ b/spec/fixtures/json_fixtures/links.json
@@ -1,0 +1,18 @@
+{
+  "version": 3,
+  "content_types": [],
+  "assets": [],
+  "entries": {
+    "cat": [
+      {
+        "sys": { "id": "foo" },
+        "fields": {
+          "link": {
+            "id": "foobar",
+            "linkType": "Entry"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The new structure uses a `fields` dictionary, so direct access to the link field's value is not possible anymore.